### PR TITLE
Internal CMHUser Error Handling Fixes

### DIFF
--- a/CMHealth.podspec
+++ b/CMHealth.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name              = "CMHealth"
-  s.version           = "0.2.2"
+  s.version           = "0.2.3"
   s.summary           = "A HIPAA compliant data storage interface for ResearchKit, from CloudMine."
   s.description       = <<-DESC
                         CMHealth is the easiest way to add secure, HIPAA compliant cloud data storage

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -23,7 +23,7 @@ PODS:
   - CloudMine (1.7.8):
     - AFNetworking (~> 2.5.4)
     - MAObjCRuntime (~> 0.0.1)
-  - CMHealth (0.1.10):
+  - CMHealth (0.2.2):
     - CloudMine (~> 1.7)
     - ResearchKit (~> 1.3)
     - TPKeyboardAvoiding (~> 1.2)
@@ -45,7 +45,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AFNetworking: 05edc0ac4c4c8cf57bcf4b84be5b0744b6d8e71e
   CloudMine: 90ca98d8a4ff2b782ad8633706dd33adc2be560c
-  CMHealth: 47212b9e44a0fdb8139725ae6ab0da661fb040df
+  CMHealth: da575b745a2e7da292f643373fbee75c00d297be
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   MAObjCRuntime: a6a1d95acbfa3784d66cb35bd42904e47943b488
   ResearchKit: 934a1efefed1a3a9150002a1e4b123d0c86c3f2e

--- a/Pod/Classes/CMHErrors.h
+++ b/Pod/Classes/CMHErrors.h
@@ -13,8 +13,11 @@ typedef NS_ENUM(NSUInteger, CMHError) {
     CMHErrorUserDidNotSign          = 704,
     CMHErrorFailedToUploadSignature = 705,
     CMHErrorUserNotLoggedIn         = 706,
-    CMHErrorResetInvalidAcct        = 707,
-    CMHErrorResetUnknownResult      = 708
+    CMHErrorInvalidAccount          = 707,
+    CMHErrorInvalidCredentials      = 708,
+    CMHErrorDuplicateAccount        = 709,
+    CMHErrorInvalidRequest          = 710,
+    CMHErrorUnknownAccountError     = 711
 };
 
 #endif

--- a/Pod/Classes/CMHUser.m
+++ b/Pod/Classes/CMHUser.m
@@ -172,7 +172,7 @@
         }
 
         if (response.objectErrors.count > 0) {
-            NSError *firstError = response.objectErrors.allKeys.firstObject;
+            NSError *firstError = response.objectErrors[response.objectErrors.allKeys.firstObject];
             block(nil, firstError);
             return;
         }

--- a/Pod/Classes/CMHUser.m
+++ b/Pod/Classes/CMHUser.m
@@ -39,17 +39,29 @@
     CMHInternalUser *newUser = [[CMHInternalUser alloc] initWithEmail:email andPassword:password];
     [CMStore defaultStore].user = newUser;
 
-    [newUser createAccountAndLoginWithCallback:^(CMUserAccountResult resultCode, NSArray *messages) {
-        NSError *error = [CMHUser errorForAccountResult:resultCode];
-        if (nil != error) {
+    [newUser createAccountWithCallback:^(CMUserAccountResult createResultCode, NSArray *messages) {
+        NSError *createError = [CMHUser errorForAccountResult:createResultCode];
+        if (nil != createError) {
             if (nil != block) {
-                block(error);
+                block(createError);
             }
             return;
         }
 
-        self.userData = [[CMHUserData alloc] initWithInternalUser:newUser];
-        block(nil);
+        [newUser loginWithCallback:^(CMUserAccountResult resultCode, NSArray *messages) {
+            NSError *loginError = [CMHUser errorForAccountResult:resultCode];
+            if (nil != loginError) {
+                if (nil != block) {
+                    block(loginError);
+                }
+                return;
+            }
+
+            self.userData = [[CMHUserData alloc] initWithInternalUser:newUser];
+            if (nil != block) {
+                block(nil);
+            }
+        }];
     }];
 }
 


### PR DESCRIPTION
Internal fixes for better error handling inside `CMHUser`. Includes a bugfix where we were failing to passback the error object, capturing all errors in the create account login flow, and errors in the local domain for all account failures.