### PR TITLE
Allow user to use CM Query syntax for ORKResult fetching

### DIFF
--- a/CMHealth.podspec
+++ b/CMHealth.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name              = "CMHealth"
-  s.version           = "0.2.3"
+  s.version           = "0.2.4"
   s.summary           = "A HIPAA compliant data storage interface for ResearchKit, from CloudMine."
   s.description       = <<-DESC
                         CMHealth is the easiest way to add secure, HIPAA compliant cloud data storage

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,34 +1,35 @@
 PODS:
-  - AFNetworking (2.5.4):
-    - AFNetworking/NSURLConnection (= 2.5.4)
-    - AFNetworking/NSURLSession (= 2.5.4)
-    - AFNetworking/Reachability (= 2.5.4)
-    - AFNetworking/Security (= 2.5.4)
-    - AFNetworking/Serialization (= 2.5.4)
-    - AFNetworking/UIKit (= 2.5.4)
-  - AFNetworking/NSURLConnection (2.5.4):
+  - AFNetworking (2.6.3):
+    - AFNetworking/NSURLConnection (= 2.6.3)
+    - AFNetworking/NSURLSession (= 2.6.3)
+    - AFNetworking/Reachability (= 2.6.3)
+    - AFNetworking/Security (= 2.6.3)
+    - AFNetworking/Serialization (= 2.6.3)
+    - AFNetworking/UIKit (= 2.6.3)
+  - AFNetworking/NSURLConnection (2.6.3):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/NSURLSession (2.5.4):
+  - AFNetworking/NSURLSession (2.6.3):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/Reachability (2.5.4)
-  - AFNetworking/Security (2.5.4)
-  - AFNetworking/Serialization (2.5.4)
-  - AFNetworking/UIKit (2.5.4):
+  - AFNetworking/Reachability (2.6.3)
+  - AFNetworking/Security (2.6.3)
+  - AFNetworking/Serialization (2.6.3)
+  - AFNetworking/UIKit (2.6.3):
     - AFNetworking/NSURLConnection
     - AFNetworking/NSURLSession
-  - CloudMine (1.7.8):
-    - AFNetworking (~> 2.5.4)
-    - MAObjCRuntime (~> 0.0.1)
+  - CloudMine (1.7.10):
+    - AFNetworking (~> 2.6.3)
+    - CloudMine/no-arc (= 1.7.10)
+  - CloudMine/no-arc (1.7.10):
+    - AFNetworking (~> 2.6.3)
   - CMHealth (0.2.2):
     - CloudMine (~> 1.7)
     - ResearchKit (~> 1.3)
     - TPKeyboardAvoiding (~> 1.2)
   - Expecta (1.0.5)
-  - MAObjCRuntime (0.0.1)
   - ResearchKit (1.3.0)
   - Specta (1.0.5)
   - TPKeyboardAvoiding (1.2.11)
@@ -43,11 +44,10 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  AFNetworking: 05edc0ac4c4c8cf57bcf4b84be5b0744b6d8e71e
-  CloudMine: 90ca98d8a4ff2b782ad8633706dd33adc2be560c
+  AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
+  CloudMine: fbe400214143095f10b357025101dd6153ec6fd4
   CMHealth: da575b745a2e7da292f643373fbee75c00d297be
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
-  MAObjCRuntime: a6a1d95acbfa3784d66cb35bd42904e47943b488
   ResearchKit: 934a1efefed1a3a9150002a1e4b123d0c86c3f2e
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
   TPKeyboardAvoiding: e5ce146b313de063957bfa75a13f1e9b0ff18ab7

--- a/Pod/Classes/ORKResult+CMHealth.h
+++ b/Pod/Classes/ORKResult+CMHealth.h
@@ -6,8 +6,21 @@ typedef void(^CMHSaveCompletion)(NSString *_Nullable uploadStatus, NSError *_Nul
 typedef void(^CMHFetchCompletion)(NSArray *_Nullable results, NSError *_Nullable error);
 
 @interface ORKResult (CMHealth)<CMCoding>
+
 - (void)cmh_saveWithCompletion:(_Nullable CMHSaveCompletion)block;
-- (void)cmh_saveToStudyWithDescriptor:(NSString *_Nullable)descriptor withCompletion:(_Nullable CMHSaveCompletion)block;
+
+- (void)cmh_saveToStudyWithDescriptor:(NSString *_Nullable)descriptor
+                       withCompletion:(_Nullable CMHSaveCompletion)block;
+
 + (void)cmh_fetchUserResultsWithCompletion:(_Nullable CMHFetchCompletion)block;
-+ (void)cmh_fetchUserResultsForStudyWithDescriptor:(NSString *_Nullable)descriptor withCompletion:(_Nullable CMHFetchCompletion)block;
+
++ (void)cmh_fetchUserResultsForStudyWithDescriptor:(NSString *_Nullable)descriptor
+                                    withCompletion:(_Nullable CMHFetchCompletion)block;
+
++ (void)cmh_fetchUserResultsForStudyWithQuery:(NSString *_Nullable)query
+                               withCompletion:(_Nullable CMHFetchCompletion)block;
+
++ (void)cmh_fetchUserResultsForStudyWithDescriptor:(NSString *_Nullable)descriptor
+                                          andQuery:(NSString *_Nullable)query
+                                    withCompletion:(_Nullable CMHFetchCompletion)block;
 @end

--- a/Pod/Classes/ORKResult+CMHealth.m
+++ b/Pod/Classes/ORKResult+CMHealth.m
@@ -54,13 +54,30 @@
 
 + (void)cmh_fetchUserResultsForStudyWithDescriptor:(NSString *_Nullable)descriptor withCompletion:(_Nullable CMHFetchCompletion)block;
 {
+    [self cmh_fetchUserResultsForStudyWithDescriptor:descriptor andQuery:nil withCompletion:block];
+}
+
++ (void)cmh_fetchUserResultsForStudyWithQuery:(NSString *_Nullable)query
+                               withCompletion:(_Nullable CMHFetchCompletion)block
+{
+    [self cmh_fetchUserResultsForStudyWithDescriptor:nil andQuery:query withCompletion:block];
+}
+
++ (void)cmh_fetchUserResultsForStudyWithDescriptor:(NSString *_Nullable)descriptor
+                                          andQuery:(NSString *_Nullable)query
+                                    withCompletion:(_Nullable CMHFetchCompletion)block
+{
     if (nil == descriptor) {
         descriptor = @"";
     }
 
-    NSString *queryString = [NSString stringWithFormat:@"[%@ = \"%@\", %@ = \"%@\"]", CMInternalClassStorageKey, [CMHResult class], CMHStudyDescriptorKey, descriptor];
+    NSString *composedQuery = [NSString stringWithFormat:@"[%@ = \"%@\", %@ = \"%@\"]", CMInternalClassStorageKey, [CMHResult class], CMHStudyDescriptorKey, descriptor];
 
-    [[CMStore defaultStore] searchUserObjects:queryString
+    if (nil != query) {
+        composedQuery = [NSString stringWithFormat:@"%@.rkResult%@", composedQuery, query];
+    }
+
+    [[CMStore defaultStore] searchUserObjects:composedQuery
                             additionalOptions:nil
                                      callback:^(CMObjectFetchResponse *response)
      {


### PR DESCRIPTION
Expose methods that enable the user to query properties on the `ORKResult` (or sublcass) when fetching from the CloudMine backend. Internally, all fetch methods are curried to a single "master" method. The use query is prepended to the internal query on the `CMHResult` wrapper, which is transparent to the user.