### PR TITLE
Polished Error Generation in User Callbacks

### DIFF
--- a/Pod/Classes/CMHErrors.h
+++ b/Pod/Classes/CMHErrors.h
@@ -19,6 +19,7 @@ typedef NS_ENUM(NSUInteger, CMHError) {
     CMHErrorDuplicateAccount        = 710,
     CMHErrorInvalidRequest          = 711,
     CMHErrorUnknownAccountError     = 712,
+    CMHErrorFailedToFetchConsent    = 713,
 };
 
 #endif

--- a/Pod/Classes/CMHErrors.h
+++ b/Pod/Classes/CMHErrors.h
@@ -12,12 +12,13 @@ typedef NS_ENUM(NSUInteger, CMHError) {
     CMHErrorUserDidNotProvideName   = 703,
     CMHErrorUserDidNotSign          = 704,
     CMHErrorFailedToUploadSignature = 705,
-    CMHErrorUserNotLoggedIn         = 706,
-    CMHErrorInvalidAccount          = 707,
-    CMHErrorInvalidCredentials      = 708,
-    CMHErrorDuplicateAccount        = 709,
-    CMHErrorInvalidRequest          = 710,
-    CMHErrorUnknownAccountError     = 711
+    CMHErrorFailedToUploadConsent   = 706,
+    CMHErrorUserNotLoggedIn         = 707,
+    CMHErrorInvalidAccount          = 708,
+    CMHErrorInvalidCredentials      = 709,
+    CMHErrorDuplicateAccount        = 710,
+    CMHErrorInvalidRequest          = 711,
+    CMHErrorUnknownAccountError     = 712,
 };
 
 #endif

--- a/Pod/Classes/CMHUser.m
+++ b/Pod/Classes/CMHUser.m
@@ -153,14 +153,10 @@
             return;
         }
 
-        if (nil != response.error) {
-            block(nil, response.error); // TODO: Consider, should we create a custom error?
-            return;
-        }
+        NSError *error = [CMHUser errorForConsentWithFetchResponse:response];
 
-        if (response.objectErrors.count > 0) {
-            NSError *firstError = response.objectErrors[response.objectErrors.allKeys.firstObject];
-            block(nil, firstError);
+        if (nil != error) {
+            block(nil, error);
             return;
         }
 
@@ -345,7 +341,7 @@
     }
 }
 
-+ (NSError *_Nullable)errorForConsentWithObjectId:(NSString *_Nonnull)objectId uploadResponse:(CMObjectUploadResponse *)response
++ (NSError *_Nullable)errorForConsentWithObjectId:(NSString *_Nonnull)objectId uploadResponse:(CMObjectUploadResponse *_Nullable)response
 {
     if (nil != response.error) {
         NSString *responseErrorMessage = [NSString localizedStringWithFormat:@"Failed to upload user consent; %@", response.error.localizedDescription];
@@ -362,6 +358,22 @@
     if(![@"created" isEqualToString:resultUploadStatus] && ![@"updated" isEqualToString:resultUploadStatus]) {
         NSString *invalidStatusMessage = [NSString localizedStringWithFormat:@"Failed to upload user consent; invalid upload status returned: %@", resultUploadStatus];
         return [CMHErrorUtilities errorWithCode:CMHErrorFailedToUploadConsent localizedDescription:invalidStatusMessage];
+    }
+
+    return nil;
+}
+
++ (NSError *_Nullable)errorForConsentWithFetchResponse:(CMObjectFetchResponse *_Nullable)response
+{
+    NSError *responseError = response.error;
+
+    if (nil == responseError) {
+        responseError = response.objectErrors[response.objectErrors.allKeys.firstObject];
+    }
+
+    if (nil != responseError) {
+        NSString *message = [NSString localizedStringWithFormat:@"Failed to fetch consent; %@", responseError.localizedDescription];
+        return [CMHErrorUtilities errorWithCode:CMHErrorFailedToFetchConsent localizedDescription:message];
     }
 
     return nil;


### PR DESCRIPTION
Consolidates all error generation into private functions internal to the `CMHUser` class. All callbacks now return errors in the local error Domain with appropriate codes and (hopefully) helpful error messages.