### PR TITLE
Enable fetching the consent signature image

### DIFF
--- a/Pod/Classes/CMHConsent.h
+++ b/Pod/Classes/CMHConsent.h
@@ -1,9 +1,13 @@
 #import <CloudMine/CloudMine.h>
 #import <ResearchKit/ResearchKit.h>
 
+typedef void(^CMHFetchSignatureCompletion)(UIImage *_Nullable signature, NSError *_Nullable error);
+
 @interface CMHConsent : CMObject
 
 @property (nonatomic, nullable, readonly) ORKTaskResult *consentResult;
 @property (nonatomic, nullable, readonly) NSString *studyDescriptor;
+
+- (void)fetchSignatureImageWithCompletion:(_Nullable CMHFetchSignatureCompletion)block;
 
 @end

--- a/Pod/Classes/CMHConsent.m
+++ b/Pod/Classes/CMHConsent.m
@@ -4,6 +4,8 @@
 
 @implementation CMHConsent
 
+#pragma mark Internal
+
 - (_Nonnull instancetype)initWithConsentResult:(ORKTaskResult *)consentResult
                      andSignatureImageFilename:(NSString *)filename
                         forStudyWithDescriptor:(NSString *)descriptor
@@ -18,13 +20,48 @@
     return self;
 }
 
+#pragma mark Public
+
+- (void)fetchSignatureImageWithCompletion:(CMHFetchSignatureCompletion)block
+{
+    /* Return the memoized image in memory rather than re-fetching
+     * This is safe because we assume the signature image will never change
+     * after initially being uploaded. To be even more efficient, we could
+     * cache the image on disk. */
+    if (nil != self.signatureImage) {
+        if (nil != block) {
+            block(self.signatureImage, nil);
+        }
+
+        return;
+    }
+
+    [CMStore.defaultStore userFileWithName:self.signatureImageFilename additionalOptions:nil callback:^(CMFileFetchResponse *response) {
+        if (nil == block) {
+            return;
+        }
+
+        if (nil != response.error) {
+            block(nil, response.error); //TODO: Local error
+        }
+
+        if (nil == response.file.fileData) {
+            block(nil, nil); //TODO: create error
+        }
+
+        UIImage *image = [UIImage imageWithData:response.file.fileData];
+        self.signatureImage = image;
+        block(image, nil);
+    }];
+}
+
+#pragma mark NSCoding
+
 - (instancetype)initWithCoder:(NSCoder *)aDecoder
 {
     self = [super initWithCoder:aDecoder];
     if (nil == self) return nil;
 
-    // TODO: Pull the wrapper class, decode the object and ensure it is of
-    // the same type as the wrapper class. Set _consentResult to the wrapper.wrappedResult
     self.consentResult = [aDecoder decodeObjectForKey:@"consentResult"];
     self.signatureImageFilename = [aDecoder decodeObjectForKey:@"signatureImageFilename"];
     self.studyDescriptor = [aDecoder decodeObjectForKey:CMHStudyDescriptorKey];

--- a/Pod/Classes/CMHConsent.m
+++ b/Pod/Classes/CMHConsent.m
@@ -55,6 +55,12 @@
         }
 
         UIImage *image = [UIImage imageWithData:response.file.fileData];
+        if (nil == image) {
+            [CMHErrorUtilities errorWithCode:CMHErrorFailedToFetchSignature
+                        localizedDescription:NSLocalizedString(@"Signature image data was invalid or corrupted", nil)];
+            return;
+        }
+
         self.signatureImage = image;
         block(image, nil);
     }];

--- a/Pod/Classes/CMHConsent.m
+++ b/Pod/Classes/CMHConsent.m
@@ -1,6 +1,8 @@
 #import "CMHConsent_internal.h"
 #import "Cocoa+CMHealth.h"
 #import "CMHConstants_internal.h"
+#import "CMHErrorUtilities.h"
+#import "CMHErrors.h"
 
 @implementation CMHConsent
 
@@ -42,11 +44,14 @@
         }
 
         if (nil != response.error) {
-            block(nil, response.error); //TODO: Local error
+            block(nil, response.error);
+            return;
         }
 
         if (nil == response.file.fileData) {
-            block(nil, nil); //TODO: create error
+            [CMHErrorUtilities errorWithCode:CMHErrorFailedToFetchSignature
+                        localizedDescription:NSLocalizedString(@"No signature image data returned", nil)];
+            return;
         }
 
         UIImage *image = [UIImage imageWithData:response.file.fileData];

--- a/Pod/Classes/CMHConsent_internal.h
+++ b/Pod/Classes/CMHConsent_internal.h
@@ -10,7 +10,9 @@
 
 @property (nonatomic, nullable, readwrite) ORKTaskResult *consentResult;
 @property (nonatomic, nullable, readwrite) NSString *studyDescriptor;
-@property (nonatomic, nullable, readwrite) NSString *signatureImageFilename;
+
+@property (nonatomic, nullable) NSString *signatureImageFilename;
+@property (nonatomic, nullable) UIImage *signatureImage;
 
 @end
 

--- a/Pod/Classes/CMHErrors.h
+++ b/Pod/Classes/CMHErrors.h
@@ -20,6 +20,7 @@ typedef NS_ENUM(NSUInteger, CMHError) {
     CMHErrorInvalidRequest          = 711,
     CMHErrorUnknownAccountError     = 712,
     CMHErrorFailedToFetchConsent    = 713,
+    CMHErrorFailedToFetchSignature  = 714,
 };
 
 #endif


### PR DESCRIPTION
**THIS PR SHOULD BE MERGED AFTER #42**

The developer can now download the user's signature image for any given consent object. The consent object itself must have previously been fetched.