### PR TITLE
Local Error generation for save and fetch results methods

### DIFF
--- a/Pod/Classes/CMHErrors.h
+++ b/Pod/Classes/CMHErrors.h
@@ -17,10 +17,17 @@ typedef NS_ENUM(NSUInteger, CMHError) {
     CMHErrorInvalidAccount          = 708,
     CMHErrorInvalidCredentials      = 709,
     CMHErrorDuplicateAccount        = 710,
-    CMHErrorInvalidRequest          = 711,
+    CMHErrorInvalidUserRequest      = 711,
     CMHErrorUnknownAccountError     = 712,
     CMHErrorFailedToFetchConsent    = 713,
     CMHErrorFailedToFetchSignature  = 714,
+    CMHErrorUnknown                 = 800,
+    CMHErrorServerConnectionFailed  = 801,
+    CMHErrorServerError             = 802,
+    CMHErrorNotFound                = 803,
+    CMHErrorInvalidRequest          = 804,
+    CMHErrorInvalidResponse         = 805,
+    CMHErrorUnauthorized            = 806,
 };
 
 #endif

--- a/Pod/Classes/CMHUser.m
+++ b/Pod/Classes/CMHUser.m
@@ -278,7 +278,7 @@
 
     switch (resultCode) {
         case CMUserAccountCreateFailedInvalidRequest:
-            code = CMHErrorInvalidRequest;
+            code = CMHErrorInvalidUserRequest;
             errorMessage = NSLocalizedString(@"Request was invalid", nil);
             break;
         case CMUserAccountProfileUpdateFailed:


### PR DESCRIPTION
When fetching and saving ORK data, CloudMine errors are now converted to errors in the local domain and returned with helpful error codes and message.