### PR TITLE
Unit Tests

### DIFF
--- a/Example/CMHealth.xcodeproj/project.pbxproj
+++ b/Example/CMHealth.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		B447ED5D1C91F8C000DC6208 /* CMHErrorUtilitiesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B447ED5C1C91F8C000DC6208 /* CMHErrorUtilitiesTests.m */; };
 		B447ED5F1C920B3A00DC6208 /* CMHCocoaCategoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B447ED5E1C920B3A00DC6208 /* CMHCocoaCategoryTests.m */; };
 		B447ED611C9220E200DC6208 /* CMHResultTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B447ED601C9220E200DC6208 /* CMHResultTests.m */; };
+		B447ED641C926FC100DC6208 /* CMHWrapperTestFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = B447ED631C926FC100DC6208 /* CMHWrapperTestFactory.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -74,6 +75,8 @@
 		B447ED5C1C91F8C000DC6208 /* CMHErrorUtilitiesTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMHErrorUtilitiesTests.m; sourceTree = "<group>"; };
 		B447ED5E1C920B3A00DC6208 /* CMHCocoaCategoryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMHCocoaCategoryTests.m; sourceTree = "<group>"; };
 		B447ED601C9220E200DC6208 /* CMHResultTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMHResultTests.m; sourceTree = "<group>"; };
+		B447ED621C926FC100DC6208 /* CMHWrapperTestFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CMHWrapperTestFactory.h; sourceTree = "<group>"; };
+		B447ED631C926FC100DC6208 /* CMHWrapperTestFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMHWrapperTestFactory.m; sourceTree = "<group>"; };
 		F0A86E2796A10F23CD8FFB5E /* Pods_CMHealth_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CMHealth_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FEB06221139C06DAA962E0A6 /* Pods-CMHealth_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CMHealth_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-CMHealth_Tests/Pods-CMHealth_Tests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -173,6 +176,8 @@
 				B447ED5C1C91F8C000DC6208 /* CMHErrorUtilitiesTests.m */,
 				B447ED5E1C920B3A00DC6208 /* CMHCocoaCategoryTests.m */,
 				B447ED601C9220E200DC6208 /* CMHResultTests.m */,
+				B447ED621C926FC100DC6208 /* CMHWrapperTestFactory.h */,
+				B447ED631C926FC100DC6208 /* CMHWrapperTestFactory.m */,
 				6003F5B6195388D20070C39A /* Supporting Files */,
 			);
 			path = Tests;
@@ -418,6 +423,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B447ED5F1C920B3A00DC6208 /* CMHCocoaCategoryTests.m in Sources */,
+				B447ED641C926FC100DC6208 /* CMHWrapperTestFactory.m in Sources */,
 				B447ED5D1C91F8C000DC6208 /* CMHErrorUtilitiesTests.m in Sources */,
 				B447ED591C8F772800DC6208 /* CMHConsentValidatorTests.m in Sources */,
 				B447ED611C9220E200DC6208 /* CMHResultTests.m in Sources */,

--- a/Example/CMHealth.xcodeproj/project.pbxproj
+++ b/Example/CMHealth.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		B447ED5F1C920B3A00DC6208 /* CMHCocoaCategoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B447ED5E1C920B3A00DC6208 /* CMHCocoaCategoryTests.m */; };
 		B447ED611C9220E200DC6208 /* CMHResultTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B447ED601C9220E200DC6208 /* CMHResultTests.m */; };
 		B447ED641C926FC100DC6208 /* CMHWrapperTestFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = B447ED631C926FC100DC6208 /* CMHWrapperTestFactory.m */; };
+		B447ED661C92710400DC6208 /* CMHConsentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B447ED651C92710400DC6208 /* CMHConsentTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -77,6 +78,7 @@
 		B447ED601C9220E200DC6208 /* CMHResultTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMHResultTests.m; sourceTree = "<group>"; };
 		B447ED621C926FC100DC6208 /* CMHWrapperTestFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CMHWrapperTestFactory.h; sourceTree = "<group>"; };
 		B447ED631C926FC100DC6208 /* CMHWrapperTestFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMHWrapperTestFactory.m; sourceTree = "<group>"; };
+		B447ED651C92710400DC6208 /* CMHConsentTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMHConsentTests.m; sourceTree = "<group>"; };
 		F0A86E2796A10F23CD8FFB5E /* Pods_CMHealth_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CMHealth_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FEB06221139C06DAA962E0A6 /* Pods-CMHealth_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CMHealth_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-CMHealth_Tests/Pods-CMHealth_Tests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -176,8 +178,7 @@
 				B447ED5C1C91F8C000DC6208 /* CMHErrorUtilitiesTests.m */,
 				B447ED5E1C920B3A00DC6208 /* CMHCocoaCategoryTests.m */,
 				B447ED601C9220E200DC6208 /* CMHResultTests.m */,
-				B447ED621C926FC100DC6208 /* CMHWrapperTestFactory.h */,
-				B447ED631C926FC100DC6208 /* CMHWrapperTestFactory.m */,
+				B447ED651C92710400DC6208 /* CMHConsentTests.m */,
 				6003F5B6195388D20070C39A /* Supporting Files */,
 			);
 			path = Tests;
@@ -186,6 +187,8 @@
 		6003F5B6195388D20070C39A /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				B447ED621C926FC100DC6208 /* CMHWrapperTestFactory.h */,
+				B447ED631C926FC100DC6208 /* CMHWrapperTestFactory.m */,
 				B447ED4E1C8DED1500DC6208 /* CMHTest-Secrets.h */,
 				6003F5B7195388D20070C39A /* Tests-Info.plist */,
 				6003F5B8195388D20070C39A /* InfoPlist.strings */,
@@ -423,6 +426,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B447ED5F1C920B3A00DC6208 /* CMHCocoaCategoryTests.m in Sources */,
+				B447ED661C92710400DC6208 /* CMHConsentTests.m in Sources */,
 				B447ED641C926FC100DC6208 /* CMHWrapperTestFactory.m in Sources */,
 				B447ED5D1C91F8C000DC6208 /* CMHErrorUtilitiesTests.m in Sources */,
 				B447ED591C8F772800DC6208 /* CMHConsentValidatorTests.m in Sources */,

--- a/Example/CMHealth.xcodeproj/project.pbxproj
+++ b/Example/CMHealth.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		97C0DAB66397A93784E32D33 /* Pods_CMHealth_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 431D85A5C170F2A74B023DD6 /* Pods_CMHealth_Tests.framework */; };
 		AADE274BB5620631181D3B4A /* Pods_CMHealth_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F0A86E2796A10F23CD8FFB5E /* Pods_CMHealth_Example.framework */; };
 		B447ED501C8E215500DC6208 /* Test-Signature-Image.png in Resources */ = {isa = PBXBuildFile; fileRef = B447ED4F1C8E215500DC6208 /* Test-Signature-Image.png */; };
+		B447ED591C8F772800DC6208 /* CMHConsentValidatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B447ED581C8F772800DC6208 /* CMHConsentValidatorTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -64,6 +65,7 @@
 		9B8848021EAD16D813BECEAA /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		B447ED4E1C8DED1500DC6208 /* CMHTest-Secrets.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CMHTest-Secrets.h"; sourceTree = "<group>"; };
 		B447ED4F1C8E215500DC6208 /* Test-Signature-Image.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Test-Signature-Image.png"; sourceTree = "<group>"; };
+		B447ED581C8F772800DC6208 /* CMHConsentValidatorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMHConsentValidatorTests.m; sourceTree = "<group>"; };
 		F0A86E2796A10F23CD8FFB5E /* Pods_CMHealth_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CMHealth_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FEB06221139C06DAA962E0A6 /* Pods-CMHealth_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CMHealth_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-CMHealth_Tests/Pods-CMHealth_Tests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -158,6 +160,7 @@
 			isa = PBXGroup;
 			children = (
 				6003F5BB195388D20070C39A /* CMHIntegrationTests.m */,
+				B447ED581C8F772800DC6208 /* CMHConsentValidatorTests.m */,
 				6003F5B6195388D20070C39A /* Supporting Files */,
 			);
 			path = Tests;
@@ -402,6 +405,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B447ED591C8F772800DC6208 /* CMHConsentValidatorTests.m in Sources */,
 				6003F5BC195388D20070C39A /* CMHIntegrationTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/CMHealth.xcodeproj/project.pbxproj
+++ b/Example/CMHealth.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		B447ED591C8F772800DC6208 /* CMHConsentValidatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B447ED581C8F772800DC6208 /* CMHConsentValidatorTests.m */; };
 		B447ED5B1C91EB3D00DC6208 /* CMHInputValidatorsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B447ED5A1C91EB3D00DC6208 /* CMHInputValidatorsTests.m */; };
 		B447ED5D1C91F8C000DC6208 /* CMHErrorUtilitiesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B447ED5C1C91F8C000DC6208 /* CMHErrorUtilitiesTests.m */; };
+		B447ED5F1C920B3A00DC6208 /* CMHCocoaCategoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B447ED5E1C920B3A00DC6208 /* CMHCocoaCategoryTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -70,6 +71,7 @@
 		B447ED581C8F772800DC6208 /* CMHConsentValidatorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMHConsentValidatorTests.m; sourceTree = "<group>"; };
 		B447ED5A1C91EB3D00DC6208 /* CMHInputValidatorsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMHInputValidatorsTests.m; sourceTree = "<group>"; };
 		B447ED5C1C91F8C000DC6208 /* CMHErrorUtilitiesTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMHErrorUtilitiesTests.m; sourceTree = "<group>"; };
+		B447ED5E1C920B3A00DC6208 /* CMHCocoaCategoryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMHCocoaCategoryTests.m; sourceTree = "<group>"; };
 		F0A86E2796A10F23CD8FFB5E /* Pods_CMHealth_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CMHealth_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FEB06221139C06DAA962E0A6 /* Pods-CMHealth_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CMHealth_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-CMHealth_Tests/Pods-CMHealth_Tests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -167,6 +169,7 @@
 				B447ED581C8F772800DC6208 /* CMHConsentValidatorTests.m */,
 				B447ED5A1C91EB3D00DC6208 /* CMHInputValidatorsTests.m */,
 				B447ED5C1C91F8C000DC6208 /* CMHErrorUtilitiesTests.m */,
+				B447ED5E1C920B3A00DC6208 /* CMHCocoaCategoryTests.m */,
 				6003F5B6195388D20070C39A /* Supporting Files */,
 			);
 			path = Tests;
@@ -411,6 +414,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B447ED5F1C920B3A00DC6208 /* CMHCocoaCategoryTests.m in Sources */,
 				B447ED5D1C91F8C000DC6208 /* CMHErrorUtilitiesTests.m in Sources */,
 				B447ED591C8F772800DC6208 /* CMHConsentValidatorTests.m in Sources */,
 				6003F5BC195388D20070C39A /* CMHIntegrationTests.m in Sources */,

--- a/Example/CMHealth.xcodeproj/project.pbxproj
+++ b/Example/CMHealth.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		B447ED5B1C91EB3D00DC6208 /* CMHInputValidatorsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B447ED5A1C91EB3D00DC6208 /* CMHInputValidatorsTests.m */; };
 		B447ED5D1C91F8C000DC6208 /* CMHErrorUtilitiesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B447ED5C1C91F8C000DC6208 /* CMHErrorUtilitiesTests.m */; };
 		B447ED5F1C920B3A00DC6208 /* CMHCocoaCategoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B447ED5E1C920B3A00DC6208 /* CMHCocoaCategoryTests.m */; };
+		B447ED611C9220E200DC6208 /* CMHResultTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B447ED601C9220E200DC6208 /* CMHResultTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -72,6 +73,7 @@
 		B447ED5A1C91EB3D00DC6208 /* CMHInputValidatorsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMHInputValidatorsTests.m; sourceTree = "<group>"; };
 		B447ED5C1C91F8C000DC6208 /* CMHErrorUtilitiesTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMHErrorUtilitiesTests.m; sourceTree = "<group>"; };
 		B447ED5E1C920B3A00DC6208 /* CMHCocoaCategoryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMHCocoaCategoryTests.m; sourceTree = "<group>"; };
+		B447ED601C9220E200DC6208 /* CMHResultTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMHResultTests.m; sourceTree = "<group>"; };
 		F0A86E2796A10F23CD8FFB5E /* Pods_CMHealth_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CMHealth_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FEB06221139C06DAA962E0A6 /* Pods-CMHealth_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CMHealth_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-CMHealth_Tests/Pods-CMHealth_Tests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -170,6 +172,7 @@
 				B447ED5A1C91EB3D00DC6208 /* CMHInputValidatorsTests.m */,
 				B447ED5C1C91F8C000DC6208 /* CMHErrorUtilitiesTests.m */,
 				B447ED5E1C920B3A00DC6208 /* CMHCocoaCategoryTests.m */,
+				B447ED601C9220E200DC6208 /* CMHResultTests.m */,
 				6003F5B6195388D20070C39A /* Supporting Files */,
 			);
 			path = Tests;
@@ -417,6 +420,7 @@
 				B447ED5F1C920B3A00DC6208 /* CMHCocoaCategoryTests.m in Sources */,
 				B447ED5D1C91F8C000DC6208 /* CMHErrorUtilitiesTests.m in Sources */,
 				B447ED591C8F772800DC6208 /* CMHConsentValidatorTests.m in Sources */,
+				B447ED611C9220E200DC6208 /* CMHResultTests.m in Sources */,
 				6003F5BC195388D20070C39A /* CMHIntegrationTests.m in Sources */,
 				B447ED5B1C91EB3D00DC6208 /* CMHInputValidatorsTests.m in Sources */,
 			);

--- a/Example/CMHealth.xcodeproj/project.pbxproj
+++ b/Example/CMHealth.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		B447ED501C8E215500DC6208 /* Test-Signature-Image.png in Resources */ = {isa = PBXBuildFile; fileRef = B447ED4F1C8E215500DC6208 /* Test-Signature-Image.png */; };
 		B447ED591C8F772800DC6208 /* CMHConsentValidatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B447ED581C8F772800DC6208 /* CMHConsentValidatorTests.m */; };
 		B447ED5B1C91EB3D00DC6208 /* CMHInputValidatorsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B447ED5A1C91EB3D00DC6208 /* CMHInputValidatorsTests.m */; };
+		B447ED5D1C91F8C000DC6208 /* CMHErrorUtilitiesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B447ED5C1C91F8C000DC6208 /* CMHErrorUtilitiesTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -68,6 +69,7 @@
 		B447ED4F1C8E215500DC6208 /* Test-Signature-Image.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Test-Signature-Image.png"; sourceTree = "<group>"; };
 		B447ED581C8F772800DC6208 /* CMHConsentValidatorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMHConsentValidatorTests.m; sourceTree = "<group>"; };
 		B447ED5A1C91EB3D00DC6208 /* CMHInputValidatorsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMHInputValidatorsTests.m; sourceTree = "<group>"; };
+		B447ED5C1C91F8C000DC6208 /* CMHErrorUtilitiesTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMHErrorUtilitiesTests.m; sourceTree = "<group>"; };
 		F0A86E2796A10F23CD8FFB5E /* Pods_CMHealth_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CMHealth_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FEB06221139C06DAA962E0A6 /* Pods-CMHealth_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CMHealth_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-CMHealth_Tests/Pods-CMHealth_Tests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -164,6 +166,7 @@
 				6003F5BB195388D20070C39A /* CMHIntegrationTests.m */,
 				B447ED581C8F772800DC6208 /* CMHConsentValidatorTests.m */,
 				B447ED5A1C91EB3D00DC6208 /* CMHInputValidatorsTests.m */,
+				B447ED5C1C91F8C000DC6208 /* CMHErrorUtilitiesTests.m */,
 				6003F5B6195388D20070C39A /* Supporting Files */,
 			);
 			path = Tests;
@@ -408,6 +411,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B447ED5D1C91F8C000DC6208 /* CMHErrorUtilitiesTests.m in Sources */,
 				B447ED591C8F772800DC6208 /* CMHConsentValidatorTests.m in Sources */,
 				6003F5BC195388D20070C39A /* CMHIntegrationTests.m in Sources */,
 				B447ED5B1C91EB3D00DC6208 /* CMHInputValidatorsTests.m in Sources */,

--- a/Example/CMHealth.xcodeproj/project.pbxproj
+++ b/Example/CMHealth.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		AADE274BB5620631181D3B4A /* Pods_CMHealth_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F0A86E2796A10F23CD8FFB5E /* Pods_CMHealth_Example.framework */; };
 		B447ED501C8E215500DC6208 /* Test-Signature-Image.png in Resources */ = {isa = PBXBuildFile; fileRef = B447ED4F1C8E215500DC6208 /* Test-Signature-Image.png */; };
 		B447ED591C8F772800DC6208 /* CMHConsentValidatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B447ED581C8F772800DC6208 /* CMHConsentValidatorTests.m */; };
+		B447ED5B1C91EB3D00DC6208 /* CMHInputValidatorsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B447ED5A1C91EB3D00DC6208 /* CMHInputValidatorsTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -66,6 +67,7 @@
 		B447ED4E1C8DED1500DC6208 /* CMHTest-Secrets.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CMHTest-Secrets.h"; sourceTree = "<group>"; };
 		B447ED4F1C8E215500DC6208 /* Test-Signature-Image.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Test-Signature-Image.png"; sourceTree = "<group>"; };
 		B447ED581C8F772800DC6208 /* CMHConsentValidatorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMHConsentValidatorTests.m; sourceTree = "<group>"; };
+		B447ED5A1C91EB3D00DC6208 /* CMHInputValidatorsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMHInputValidatorsTests.m; sourceTree = "<group>"; };
 		F0A86E2796A10F23CD8FFB5E /* Pods_CMHealth_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CMHealth_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FEB06221139C06DAA962E0A6 /* Pods-CMHealth_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CMHealth_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-CMHealth_Tests/Pods-CMHealth_Tests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -161,6 +163,7 @@
 			children = (
 				6003F5BB195388D20070C39A /* CMHIntegrationTests.m */,
 				B447ED581C8F772800DC6208 /* CMHConsentValidatorTests.m */,
+				B447ED5A1C91EB3D00DC6208 /* CMHInputValidatorsTests.m */,
 				6003F5B6195388D20070C39A /* Supporting Files */,
 			);
 			path = Tests;
@@ -407,6 +410,7 @@
 			files = (
 				B447ED591C8F772800DC6208 /* CMHConsentValidatorTests.m in Sources */,
 				6003F5BC195388D20070C39A /* CMHIntegrationTests.m in Sources */,
+				B447ED5B1C91EB3D00DC6208 /* CMHInputValidatorsTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/Tests/CMHCocoaCategoryTests.m
+++ b/Example/Tests/CMHCocoaCategoryTests.m
@@ -1,0 +1,23 @@
+#import <Foundation/Foundation.h>
+#import <CMHealth/Cocoa+CMHealth.h>
+#import <CloudMine/CloudMine.h>
+
+SpecBegin(CMHCocoaCategoryTests)
+
+describe(@"NSUUID", ^{
+    it(@"should encode and decode properly with an NSCoder", ^{
+        NSUUID *origId = [NSUUID new];
+        NSData *idData = [NSKeyedArchiver archivedDataWithRootObject:origId];
+        NSUUID *codedId = [NSKeyedUnarchiver unarchiveObjectWithData:idData];
+
+        expect(origId == codedId).to.beFalsy();
+        expect(origId).to.equal(codedId);
+    });
+
+    pending(@"should encode and decode properly with a CMCoder", ^{
+
+    });
+});
+
+
+SpecEnd

--- a/Example/Tests/CMHCocoaCategoryTests.m
+++ b/Example/Tests/CMHCocoaCategoryTests.m
@@ -61,5 +61,20 @@ describe(@"NSUUID", ^{
     });
 });
 
+describe(@"UIImage", ^{
+    it(@"should encode and decode properly with NSCoder", ^{
+        // Bug in Cocoa? See: http://stackoverflow.com/questions/26213575/unarchive-uiimage-object-returns-cgsizezero-image-using-nskeyedunarchiver-on-ios
+        UIImage *assetImage = [UIImage imageNamed:@"Test-Signature-Image.png"];
+
+        UIImage *origImage = [UIImage imageWithCGImage:assetImage.CGImage scale:assetImage.scale orientation:assetImage.imageOrientation];
+        NSData *imageData = [NSKeyedArchiver archivedDataWithRootObject:origImage];
+        UIImage *codedImage = [NSKeyedUnarchiver unarchiveObjectWithData:imageData];
+
+        expect(origImage == codedImage).to.beFalsy();
+        expect(codedImage.size.width).to.equal(origImage.size.width);
+        expect(codedImage.size.height).to.equal(origImage.size.height);
+    });
+});
+
 
 SpecEnd

--- a/Example/Tests/CMHCocoaCategoryTests.m
+++ b/Example/Tests/CMHCocoaCategoryTests.m
@@ -2,10 +2,45 @@
 #import <CMHealth/Cocoa+CMHealth.h>
 #import <CloudMine/CloudMine.h>
 
+@interface CMHTestUUIDWrapper : CMObject
+- (instancetype)initWithUUID:(NSUUID *)uuid;
+@property (nonatomic) NSUUID *uuid;
+@end
+
+@implementation CMHTestUUIDWrapper
+
+- (instancetype)initWithUUID:(NSUUID *)uuid
+{
+    self = [super init];
+    if (nil == self) return nil;
+
+    self.uuid = uuid;
+
+    return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
+{
+    self = [super initWithCoder:aDecoder];
+    if (nil == self) return nil;
+
+    self.uuid = [aDecoder decodeObjectForKey:@"uuid"];
+
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder
+{
+    [super encodeWithCoder:aCoder];
+    [aCoder encodeObject:self.uuid forKey:@"uuid"];
+}
+
+@end
+
 SpecBegin(CMHCocoaCategoryTests)
 
 describe(@"NSUUID", ^{
-    it(@"should encode and decode properly with an NSCoder", ^{
+    it(@"should encode and decode properly with NSCoder", ^{
         NSUUID *origId = [NSUUID new];
         NSData *idData = [NSKeyedArchiver archivedDataWithRootObject:origId];
         NSUUID *codedId = [NSKeyedUnarchiver unarchiveObjectWithData:idData];
@@ -14,8 +49,15 @@ describe(@"NSUUID", ^{
         expect(origId).to.equal(codedId);
     });
 
-    pending(@"should encode and decode properly with a CMCoder", ^{
+    it(@"should encode and decode properly with CMCoder", ^{
+        CMHTestUUIDWrapper *origWrapper = [[CMHTestUUIDWrapper alloc] initWithUUID:[NSUUID new]];
+        NSDictionary *encodedObjects = [CMObjectEncoder encodeObjects:@[origWrapper]];
+        CMHTestUUIDWrapper *codedWrapper = [CMObjectDecoder decodeObjects:encodedObjects].firstObject;
 
+        expect(origWrapper == codedWrapper).to.beFalsy();
+        expect(origWrapper.uuid == codedWrapper.uuid).to.beFalsy();
+        expect(codedWrapper.uuid).to.equal(origWrapper.uuid);
+        expect(encodedObjects[origWrapper.objectId][@"uuid"][@"UUIDString"]).to.equal(origWrapper.uuid.UUIDString);
     });
 });
 

--- a/Example/Tests/CMHConsentTests.m
+++ b/Example/Tests/CMHConsentTests.m
@@ -1,0 +1,51 @@
+#import <Foundation/Foundation.h>
+#import <CMHealth/CMHealth.h>
+#import <CMHealth/CMHConsent_internal.h>
+#import <CloudMine/CloudMine.h>
+#import "CMHWrapperTestFactory.h"
+
+static NSString *const TestDescriptor = @"CMHTestDescriptor";
+static NSString *const TestFileName   = @"CMHTestFileName";
+
+SpecBegin(CMHConsent)
+
+describe(@"CMHConsent", ^{
+    it(@"should retain the result, filename, and descriptor", ^{
+        ORKTaskResult *taskResult = CMHWrapperTestFactory.taskResult;
+        CMHConsent *consent = [[CMHConsent alloc] initWithConsentResult:taskResult
+                                              andSignatureImageFilename:TestFileName
+                                                 forStudyWithDescriptor:TestDescriptor];
+
+        expect(consent.consentResult == taskResult).to.beTruthy();
+        expect(consent.signatureImageFilename).to.equal(TestFileName);
+        expect(consent.studyDescriptor).to.equal(TestDescriptor);
+    });
+
+    it(@"should encode and decode properly with NSCoder", ^{
+        CMHConsent *origConsent = [[CMHConsent alloc] initWithConsentResult:CMHWrapperTestFactory.taskResult
+                                                  andSignatureImageFilename:TestFileName
+                                                     forStudyWithDescriptor:TestDescriptor];
+        NSData *consentData = [NSKeyedArchiver archivedDataWithRootObject:origConsent];
+        CMHConsent *codedConsent = [NSKeyedUnarchiver unarchiveObjectWithData:consentData];
+
+        expect(codedConsent == origConsent).to.beFalsy();
+        expect([CMHWrapperTestFactory isEquivalent:codedConsent.consentResult]).to.beTruthy();
+        expect(codedConsent.studyDescriptor).to.equal(TestDescriptor);
+        expect(codedConsent.signatureImageFilename).to.equal(TestFileName);
+    });
+
+    it(@"should encode and decode properly with CMCoder", ^{
+        CMHConsent *origConsent = [[CMHConsent alloc] initWithConsentResult:CMHWrapperTestFactory.taskResult
+                                                  andSignatureImageFilename:TestFileName
+                                                     forStudyWithDescriptor:TestDescriptor];
+        NSDictionary *encodedObjects = [CMObjectEncoder encodeObjects:@[origConsent]];
+        CMHConsent *codedConsent = [CMObjectDecoder decodeObjects:encodedObjects].firstObject;
+
+        expect(codedConsent == origConsent).to.beFalsy();
+        expect([CMHWrapperTestFactory isEquivalent:codedConsent.consentResult]).to.beTruthy();
+        expect(codedConsent.studyDescriptor).to.equal(TestDescriptor);
+        expect(codedConsent.signatureImageFilename).to.equal(TestFileName);
+    });
+});
+
+SpecEnd

--- a/Example/Tests/CMHConsentValidatorTests.m
+++ b/Example/Tests/CMHConsentValidatorTests.m
@@ -3,10 +3,20 @@
 #import <CMHealth/CMHConsentValidator.h>
 
 @interface CMHConsentValidatorTestFactory : NSObject
++ (ORKConsentSignatureResult *)validSignatureResult;
 + (ORKConsentSignature *)validSignature;
 @end
 
 @implementation CMHConsentValidatorTestFactory
+
++ (ORKConsentSignatureResult *)validSignatureResult
+{
+    ORKConsentSignatureResult *signatureResult = [ORKConsentSignatureResult new];
+    signatureResult.consented = YES;
+    signatureResult.signature = CMHConsentValidatorTestFactory.validSignature;
+
+    return signatureResult;
+}
 
 + (ORKConsentSignature *)validSignature
 {
@@ -51,9 +61,8 @@ describe(@"CMHConsentValidator", ^{
 
         ORKTaskResult *taskResult = [[ORKTaskResult alloc] initWithTaskIdentifier:@"CMHTestIdentifier" taskRunUUID:[NSUUID new] outputDirectory:nil];
 
-        ORKConsentSignatureResult *signatureResult = [ORKConsentSignatureResult new];
+        ORKConsentSignatureResult *signatureResult = CMHConsentValidatorTestFactory.validSignatureResult;
         signatureResult.consented = NO;
-        signatureResult.signature = CMHConsentValidatorTestFactory.validSignature;
 
         taskResult.results = @[signatureResult];
 
@@ -69,10 +78,7 @@ describe(@"CMHConsentValidator", ^{
 
         ORKTaskResult *taskResult = [[ORKTaskResult alloc] initWithTaskIdentifier:@"CMHTestIdentifier" taskRunUUID:[NSUUID new] outputDirectory:nil];
 
-        ORKConsentSignatureResult *signatureResult = [ORKConsentSignatureResult new];
-        signatureResult.consented = YES;
-
-        signatureResult.signature = CMHConsentValidatorTestFactory.validSignature;
+        ORKConsentSignatureResult *signatureResult = CMHConsentValidatorTestFactory.validSignatureResult;
         signatureResult.signature.familyName = nil;
         signatureResult.signature.givenName = nil;
 
@@ -90,10 +96,7 @@ describe(@"CMHConsentValidator", ^{
 
         ORKTaskResult *taskResult = [[ORKTaskResult alloc] initWithTaskIdentifier:@"CMHTestIdentifier" taskRunUUID:[NSUUID new] outputDirectory:nil];
 
-        ORKConsentSignatureResult *signatureResult = [ORKConsentSignatureResult new];
-        signatureResult.consented = YES;
-
-        signatureResult.signature = CMHConsentValidatorTestFactory.validSignature;
+        ORKConsentSignatureResult *signatureResult = CMHConsentValidatorTestFactory.validSignatureResult;
         signatureResult.signature.signatureImage = nil;
 
         taskResult.results = @[signatureResult];

--- a/Example/Tests/CMHConsentValidatorTests.m
+++ b/Example/Tests/CMHConsentValidatorTests.m
@@ -107,6 +107,38 @@ describe(@"CMHConsentValidator", ^{
         expect(error).notTo.beNil();
         expect(error.code).to.equal(CMHErrorUserDidNotSign);
     });
+
+    it(@"should find a valid signature if it is at the top level of the results", ^{
+        NSError *error = nil;
+
+        ORKTaskResult *taskResult = [[ORKTaskResult alloc] initWithTaskIdentifier:@"CMHTestIdentifier" taskRunUUID:[NSUUID new] outputDirectory:nil];
+        ORKConsentSignatureResult *signatureResult = CMHConsentValidatorTestFactory.validSignatureResult;
+        taskResult.results = @[signatureResult];
+
+        ORKConsentSignature *signature = [CMHConsentValidator signatureFromConsentResults:taskResult error:&error];
+
+        expect(error).to.beNil();
+        expect(signature).to.equal(signatureResult.signature);
+    });
+
+    it(@"should find a valid signature if it is arbitrarily nested", ^{
+        NSError *error = nil;
+
+
+        ORKTaskResult *topResult = [[ORKTaskResult alloc] initWithTaskIdentifier:@"CMHTestIdentifier" taskRunUUID:[NSUUID new] outputDirectory:nil];
+        ORKTaskResult *firstResult = [[ORKTaskResult alloc] initWithTaskIdentifier:@"CMHTestIdentifier1" taskRunUUID:[NSUUID new] outputDirectory:nil];
+        ORKTaskResult *secondResult = [[ORKTaskResult alloc] initWithTaskIdentifier:@"CMHTestIdentifier2" taskRunUUID:[NSUUID new] outputDirectory:nil];
+        ORKStepResult *finalResult = [[ORKStepResult alloc] initWithStepIdentifier:@"" results:nil];
+
+        finalResult.results = @[ORKTextQuestionResult.new, CMHConsentValidatorTestFactory.validSignatureResult, ORKTextQuestionResult.new];
+        secondResult.results = @[finalResult];
+        topResult.results = @[firstResult, secondResult];
+
+        ORKConsentSignature *signature = [CMHConsentValidator signatureFromConsentResults:topResult error:&error];
+
+        expect(error).to.beNil();
+        expect(signature).to.equal([(ORKConsentSignatureResult *)[finalResult.results objectAtIndex:1] signature]);
+    });
 });
 
 SpecEnd

--- a/Example/Tests/CMHConsentValidatorTests.m
+++ b/Example/Tests/CMHConsentValidatorTests.m
@@ -1,0 +1,100 @@
+#import <Foundation/Foundation.h>
+#import <CMHealth/CMHealth.h>
+#import <CMHealth/CMHConsentValidator.h>
+
+SpecBegin(CMHealthConsentValidator)
+
+describe(@"CMHConsentValidator", ^{
+    it(@"should produce an error for a nil consent task", ^{
+        NSError *error = nil;
+
+        ORKConsentSignature *signature = [CMHConsentValidator signatureFromConsentResults:nil error:&error];
+
+        expect(signature).to.beNil();
+        expect(error).notTo.beNil();
+        expect(error.code).to.equal(CMHErrorUserMissingConsent);
+    });
+
+    it(@"should produce an error for a task result with no signature", ^{
+        NSError *error = nil;
+
+        ORKTaskResult *taskResult = [[ORKTaskResult alloc] initWithTaskIdentifier:@"CMHTestIdentifier" taskRunUUID:[NSUUID new] outputDirectory:nil];
+
+        ORKConsentSignature *signature = [CMHConsentValidator signatureFromConsentResults:taskResult error:&error];
+
+        expect(signature).to.beNil();
+        expect(error).notTo.beNil();
+        expect(error.code).to.equal(CMHErrorUserMissingSignature);
+    });
+
+    it(@"should produce an error if the user did not consent", ^{
+        NSError *error = nil;
+
+        ORKTaskResult *taskResult = [[ORKTaskResult alloc] initWithTaskIdentifier:@"CMHTestIdentifier" taskRunUUID:[NSUUID new] outputDirectory:nil];
+
+        ORKConsentSignatureResult *signatureResult = [ORKConsentSignatureResult new];
+        signatureResult.consented = NO;
+        signatureResult.signature = [ORKConsentSignature signatureForPersonWithTitle:nil
+                                                                    dateFormatString:nil
+                                                                          identifier:@"CMHTestIdentifier"
+                                                                           givenName:@"John"
+                                                                          familyName:@"Doe"
+                                                                      signatureImage:[UIImage imageNamed:@"Test-Signature-Image.png"]
+                                                                          dateString:nil];
+        taskResult.results = @[signatureResult];
+
+        ORKConsentSignature *signature = [CMHConsentValidator signatureFromConsentResults:taskResult error:&error];
+
+        expect(signature).to.beNil();
+        expect(error).notTo.beNil();
+        expect(error.code).to.equal(CMHErrorUserDidNotConsent);
+    });
+
+    it(@"should produce an error if the family and given name are not included", ^{
+        NSError *error = nil;
+
+        ORKTaskResult *taskResult = [[ORKTaskResult alloc] initWithTaskIdentifier:@"CMHTestIdentifier" taskRunUUID:[NSUUID new] outputDirectory:nil];
+
+        ORKConsentSignatureResult *signatureResult = [ORKConsentSignatureResult new];
+        signatureResult.consented = YES;
+        signatureResult.signature = [ORKConsentSignature signatureForPersonWithTitle:nil
+                                                                    dateFormatString:nil
+                                                                          identifier:@"CMHTestIdentifier"
+                                                                           givenName:nil
+                                                                          familyName:nil
+                                                                      signatureImage:[UIImage imageNamed:@"Test-Signature-Image.png"]
+                                                                          dateString:nil];
+        taskResult.results = @[signatureResult];
+
+        ORKConsentSignature *signature = [CMHConsentValidator signatureFromConsentResults:taskResult error:&error];
+
+        expect(signature).to.beNil();
+        expect(error).notTo.beNil();
+        expect(error.code).to.equal(CMHErrorUserDidNotProvideName);
+    });
+
+    it(@"should produce an error if the signature image is not included", ^{
+        NSError *error = nil;
+
+        ORKTaskResult *taskResult = [[ORKTaskResult alloc] initWithTaskIdentifier:@"CMHTestIdentifier" taskRunUUID:[NSUUID new] outputDirectory:nil];
+
+        ORKConsentSignatureResult *signatureResult = [ORKConsentSignatureResult new];
+        signatureResult.consented = YES;
+        signatureResult.signature = [ORKConsentSignature signatureForPersonWithTitle:nil
+                                                                    dateFormatString:nil
+                                                                          identifier:@"CMHTestIdentifier"
+                                                                           givenName:@"John"
+                                                                          familyName:@"Doe"
+                                                                      signatureImage:nil
+                                                                          dateString:nil];
+        taskResult.results = @[signatureResult];
+
+        ORKConsentSignature *signature = [CMHConsentValidator signatureFromConsentResults:taskResult error:&error];
+
+        expect(signature).to.beNil();
+        expect(error).notTo.beNil();
+        expect(error.code).to.equal(CMHErrorUserDidNotSign);
+    });
+});
+
+SpecEnd

--- a/Example/Tests/CMHConsentValidatorTests.m
+++ b/Example/Tests/CMHConsentValidatorTests.m
@@ -2,6 +2,25 @@
 #import <CMHealth/CMHealth.h>
 #import <CMHealth/CMHConsentValidator.h>
 
+@interface CMHConsentValidatorTestFactory : NSObject
++ (ORKConsentSignature *)validSignature;
+@end
+
+@implementation CMHConsentValidatorTestFactory
+
++ (ORKConsentSignature *)validSignature
+{
+    return [ORKConsentSignature signatureForPersonWithTitle:nil
+                                           dateFormatString:nil
+                                                 identifier:@"CMHTestIdentifier"
+                                                  givenName:@"John"
+                                                 familyName:@"Doe"
+                                             signatureImage:[UIImage imageNamed:@"Test-Signature-Image.png"]
+                                                 dateString:nil];
+}
+
+@end
+
 SpecBegin(CMHealthConsentValidator)
 
 describe(@"CMHConsentValidator", ^{
@@ -34,13 +53,8 @@ describe(@"CMHConsentValidator", ^{
 
         ORKConsentSignatureResult *signatureResult = [ORKConsentSignatureResult new];
         signatureResult.consented = NO;
-        signatureResult.signature = [ORKConsentSignature signatureForPersonWithTitle:nil
-                                                                    dateFormatString:nil
-                                                                          identifier:@"CMHTestIdentifier"
-                                                                           givenName:@"John"
-                                                                          familyName:@"Doe"
-                                                                      signatureImage:[UIImage imageNamed:@"Test-Signature-Image.png"]
-                                                                          dateString:nil];
+        signatureResult.signature = CMHConsentValidatorTestFactory.validSignature;
+
         taskResult.results = @[signatureResult];
 
         ORKConsentSignature *signature = [CMHConsentValidator signatureFromConsentResults:taskResult error:&error];
@@ -57,13 +71,11 @@ describe(@"CMHConsentValidator", ^{
 
         ORKConsentSignatureResult *signatureResult = [ORKConsentSignatureResult new];
         signatureResult.consented = YES;
-        signatureResult.signature = [ORKConsentSignature signatureForPersonWithTitle:nil
-                                                                    dateFormatString:nil
-                                                                          identifier:@"CMHTestIdentifier"
-                                                                           givenName:nil
-                                                                          familyName:nil
-                                                                      signatureImage:[UIImage imageNamed:@"Test-Signature-Image.png"]
-                                                                          dateString:nil];
+
+        signatureResult.signature = CMHConsentValidatorTestFactory.validSignature;
+        signatureResult.signature.familyName = nil;
+        signatureResult.signature.givenName = nil;
+
         taskResult.results = @[signatureResult];
 
         ORKConsentSignature *signature = [CMHConsentValidator signatureFromConsentResults:taskResult error:&error];
@@ -80,13 +92,10 @@ describe(@"CMHConsentValidator", ^{
 
         ORKConsentSignatureResult *signatureResult = [ORKConsentSignatureResult new];
         signatureResult.consented = YES;
-        signatureResult.signature = [ORKConsentSignature signatureForPersonWithTitle:nil
-                                                                    dateFormatString:nil
-                                                                          identifier:@"CMHTestIdentifier"
-                                                                           givenName:@"John"
-                                                                          familyName:@"Doe"
-                                                                      signatureImage:nil
-                                                                          dateString:nil];
+
+        signatureResult.signature = CMHConsentValidatorTestFactory.validSignature;
+        signatureResult.signature.signatureImage = nil;
+
         taskResult.results = @[signatureResult];
 
         ORKConsentSignature *signature = [CMHConsentValidator signatureFromConsentResults:taskResult error:&error];

--- a/Example/Tests/CMHErrorUtilitiesTests.m
+++ b/Example/Tests/CMHErrorUtilitiesTests.m
@@ -1,0 +1,17 @@
+#import <Foundation/Foundation.h>
+#import <CMHealth/CMHealth.h>
+#import <CMHealth/CMHErrorUtilities.h>
+
+SpecBegin(CMHErrorUtilities)
+
+describe(@"CMHErrorUtilities", ^{
+    it(@"Should produce an error with the correct domain, and given code and description", ^{
+        NSError *testError = [CMHErrorUtilities errorWithCode:CMHErrorUnknown localizedDescription:@"Test Error Description"];
+
+        expect(testError.code).to.equal(CMHErrorUnknown);
+        expect(testError.domain).to.equal(CMHErrorDomain);
+        expect(testError.localizedDescription).to.equal(@"Test Error Description");
+    });
+});
+
+SpecEnd

--- a/Example/Tests/CMHInputValidatorsTests.m
+++ b/Example/Tests/CMHInputValidatorsTests.m
@@ -19,8 +19,18 @@ describe(@"CMHInputValidators", ^{
         expect(errorMessage).notTo.beNil();
     });
 
-    pending(@"should return an error message for an email that has two @'s'", ^{
+    it(@"should return an error message for an email that has two @'s", ^{
         NSString *errorMessage = [CMHInputValidators localizedValidationErrorMessageForEmail:@"t@est@test.com"];
+        expect(errorMessage).notTo.beNil();
+    });
+
+    it(@"should return an error message for an email with two @'s and one at the beginning", ^{
+        NSString *errorMessage = [CMHInputValidators localizedValidationErrorMessageForEmail:@"@est@test.com"];
+        expect(errorMessage).notTo.beNil();
+    });
+
+    it(@"should return an error message for an email with two @'s and one at the end", ^{
+        NSString *errorMessage = [CMHInputValidators localizedValidationErrorMessageForEmail:@"test@test.com@"];
         expect(errorMessage).notTo.beNil();
     });
 

--- a/Example/Tests/CMHInputValidatorsTests.m
+++ b/Example/Tests/CMHInputValidatorsTests.m
@@ -1,0 +1,68 @@
+#import <Foundation/Foundation.h>
+#import <CMHealth/CMHInputValidators.h>
+
+SpecBegin(CMHealthInputValidators)
+
+describe(@"CMHInputValidators", ^{
+    it(@"should return an error message for a nil email", ^{
+        NSString *errorMessage = [CMHInputValidators localizedValidationErrorMessageForEmail:nil];
+        expect(errorMessage).notTo.beNil();
+    });
+
+    it(@"should return an error message for an empty email", ^{
+        NSString *errorMessage = [CMHInputValidators localizedValidationErrorMessageForEmail:@""];
+        expect(errorMessage).notTo.beNil();
+    });
+
+    it(@"should return an error message for an email that doesn't have an @", ^{
+        NSString *errorMessage = [CMHInputValidators localizedValidationErrorMessageForEmail:@"test#test.com"];
+        expect(errorMessage).notTo.beNil();
+    });
+
+    pending(@"should return an error message for an email that has two @'s'", ^{
+        NSString *errorMessage = [CMHInputValidators localizedValidationErrorMessageForEmail:@"t@est@test.com"];
+        expect(errorMessage).notTo.beNil();
+    });
+
+    it(@"should return an error message for an email that doesn't have a TLD", ^{
+        NSString *errorMessage = [CMHInputValidators localizedValidationErrorMessageForEmail:@"te.st@testcom"];
+        expect(errorMessage).notTo.beNil();
+    });
+
+    it(@"should return an error message for an email that doesn't have a name", ^{
+        NSString *errorMessage = [CMHInputValidators localizedValidationErrorMessageForEmail:@"@test.com"];
+        expect(errorMessage).notTo.beNil();
+    });
+
+    it(@"should return an error message for an email that ends in a dot without a TLD", ^{
+        NSString *errorMessage = [CMHInputValidators localizedValidationErrorMessageForEmail:@"test@test."];
+        expect(errorMessage).notTo.beNil();
+    });
+
+    it(@"should return an error message for an email that ends in a dot after the TLD", ^{
+        NSString *errorMessage = [CMHInputValidators localizedValidationErrorMessageForEmail:@"test@test.com."];
+        expect(errorMessage).notTo.beNil();
+    });
+
+    it(@"should return an error message for an email thats missing the domain", ^{
+        NSString *errorMessage = [CMHInputValidators localizedValidationErrorMessageForEmail:@"test@"];
+        expect(errorMessage).notTo.beNil();
+    });
+
+    it(@"should return nil for a valid email", ^{
+        NSString *errorMessage = [CMHInputValidators localizedValidationErrorMessageForEmail:@"test@test.com"];
+        expect(errorMessage).to.beNil();
+    });
+
+    it(@"should return a nil for a valid email with a dot in the name", ^{
+        NSString *errorMessage = [CMHInputValidators localizedValidationErrorMessageForEmail:@"te.st@test.com"];
+        expect(errorMessage).to.beNil();
+    });
+
+    it(@"should return a nil for a valid email with a dot in the domain", ^{
+        NSString *errorMessage = [CMHInputValidators localizedValidationErrorMessageForEmail:@"test@test.co.uk"];
+        expect(errorMessage).to.beNil();
+    });
+});
+
+SpecEnd

--- a/Example/Tests/CMHResultTests.m
+++ b/Example/Tests/CMHResultTests.m
@@ -1,0 +1,63 @@
+#import <Foundation/Foundation.h>
+#import <CMHealth/CMHResult.h>
+
+static NSString *const TestDescriptor = @"CMHTestDescriptor";
+
+@interface CMHResultTestFactory : NSObject
++ (ORKTaskResult *)taskResult;
+@end
+
+@implementation CMHResultTestFactory
+
++ (ORKTaskResult *)taskResult
+{
+    ORKTextQuestionResult *textQuestionResult = [ORKTextQuestionResult new];
+    textQuestionResult.textAnswer = @"TestAnswer";
+
+    ORKScaleQuestionResult *scaleQuestionResult = [ORKScaleQuestionResult new];
+    scaleQuestionResult.scaleAnswer = [NSNumber numberWithFloat:1.16f];
+
+    ORKStepResult *stepResult = [[ORKStepResult alloc] initWithStepIdentifier:@"CMHTestStepIdentifier" results:@[textQuestionResult, scaleQuestionResult]];
+
+    ORKTaskResult *taskResult = [[ORKTaskResult alloc] initWithIdentifier:@"CMHTestIdentifier"];
+    taskResult.results = @[stepResult];
+
+    return taskResult;
+}
+
++ (BOOL)isEquivalent:(ORKTaskResult *)taskResult
+{
+    return [taskResult.identifier isEqualToString:@"CMHTestIdentifier"] &&
+            [taskResult.firstResult isKindOfClass:[ORKStepResult class]] &&
+            [taskResult.firstResult.identifier isEqualToString:@"CMHTestStepIdentifier"] &&
+            [((ORKStepResult *)taskResult.firstResult).results[0] isKindOfClass:[ORKTextQuestionResult class]] &&
+            [((ORKTextQuestionResult *)((ORKStepResult *)taskResult.firstResult).results[0]).textAnswer isEqualToString:@"TestAnswer"] &&
+            [((ORKStepResult *)taskResult.firstResult).results[1] isKindOfClass:[ORKScaleQuestionResult class]] &&
+            ((ORKScaleQuestionResult *)((ORKStepResult *)taskResult.firstResult).results[1]).scaleAnswer.floatValue == 1.16f;
+}
+
+@end
+
+SpecBegin(CMHResult)
+
+describe(@"CMHResult", ^{
+    it(@"should retain the result and descriptor", ^{
+        ORKResult *orkResult = [[ORKResult alloc] initWithIdentifier:@"TestIdentifier"];
+        CMHResult *result = [[CMHResult alloc] initWithResearchKitResult:orkResult andStudyDescriptor:TestDescriptor];
+
+        expect(result.rkResult).to.equal(orkResult);
+        expect(result.studyDescriptor).to.equal(TestDescriptor);
+    });
+
+    it(@"should encode and decode properly with NSCoder", ^{
+        CMHResult *origResult = [[CMHResult alloc] initWithResearchKitResult:CMHResultTestFactory.taskResult andStudyDescriptor:TestDescriptor];
+        NSData *resultData = [NSKeyedArchiver archivedDataWithRootObject:origResult];
+        CMHResult *codedResult = [NSKeyedUnarchiver unarchiveObjectWithData:resultData];
+
+        expect(codedResult == origResult).to.beFalsy();
+        expect([CMHResultTestFactory isEquivalent:(ORKTaskResult *)codedResult.rkResult]).to.beTruthy();
+        expect(codedResult.studyDescriptor).to.equal(TestDescriptor);
+    });
+});
+
+SpecEnd

--- a/Example/Tests/CMHResultTests.m
+++ b/Example/Tests/CMHResultTests.m
@@ -1,42 +1,8 @@
 #import <Foundation/Foundation.h>
 #import <CMHealth/CMHResult.h>
+#import "CMHWrapperTestFactory.h"
 
 static NSString *const TestDescriptor = @"CMHTestDescriptor";
-
-@interface CMHResultTestFactory : NSObject
-+ (ORKTaskResult *)taskResult;
-@end
-
-@implementation CMHResultTestFactory
-
-+ (ORKTaskResult *)taskResult
-{
-    ORKTextQuestionResult *textQuestionResult = [ORKTextQuestionResult new];
-    textQuestionResult.textAnswer = @"TestAnswer";
-
-    ORKScaleQuestionResult *scaleQuestionResult = [ORKScaleQuestionResult new];
-    scaleQuestionResult.scaleAnswer = [NSNumber numberWithFloat:1.16f];
-
-    ORKStepResult *stepResult = [[ORKStepResult alloc] initWithStepIdentifier:@"CMHTestStepIdentifier" results:@[textQuestionResult, scaleQuestionResult]];
-
-    ORKTaskResult *taskResult = [[ORKTaskResult alloc] initWithIdentifier:@"CMHTestIdentifier"];
-    taskResult.results = @[stepResult];
-
-    return taskResult;
-}
-
-+ (BOOL)isEquivalent:(ORKTaskResult *)taskResult
-{
-    return [taskResult.identifier isEqualToString:@"CMHTestIdentifier"] &&
-            [taskResult.firstResult isKindOfClass:[ORKStepResult class]] &&
-            [taskResult.firstResult.identifier isEqualToString:@"CMHTestStepIdentifier"] &&
-            [((ORKStepResult *)taskResult.firstResult).results[0] isKindOfClass:[ORKTextQuestionResult class]] &&
-            [((ORKTextQuestionResult *)((ORKStepResult *)taskResult.firstResult).results[0]).textAnswer isEqualToString:@"TestAnswer"] &&
-            [((ORKStepResult *)taskResult.firstResult).results[1] isKindOfClass:[ORKScaleQuestionResult class]] &&
-            ((ORKScaleQuestionResult *)((ORKStepResult *)taskResult.firstResult).results[1]).scaleAnswer.floatValue == 1.16f;
-}
-
-@end
 
 SpecBegin(CMHResult)
 
@@ -50,22 +16,22 @@ describe(@"CMHResult", ^{
     });
 
     it(@"should encode and decode properly with NSCoder", ^{
-        CMHResult *origResult = [[CMHResult alloc] initWithResearchKitResult:CMHResultTestFactory.taskResult andStudyDescriptor:TestDescriptor];
+        CMHResult *origResult = [[CMHResult alloc] initWithResearchKitResult:CMHWrapperTestFactory.taskResult andStudyDescriptor:TestDescriptor];
         NSData *resultData = [NSKeyedArchiver archivedDataWithRootObject:origResult];
         CMHResult *codedResult = [NSKeyedUnarchiver unarchiveObjectWithData:resultData];
 
         expect(codedResult == origResult).to.beFalsy();
-        expect([CMHResultTestFactory isEquivalent:(ORKTaskResult *)codedResult.rkResult]).to.beTruthy();
+        expect([CMHWrapperTestFactory isEquivalent:(ORKTaskResult *)codedResult.rkResult]).to.beTruthy();
         expect(codedResult.studyDescriptor).to.equal(TestDescriptor);
     });
 
     it(@"should encode and decode properly with CMCoder", ^{
-        CMHResult *origResult = [[CMHResult alloc] initWithResearchKitResult:CMHResultTestFactory.taskResult andStudyDescriptor:TestDescriptor];
+        CMHResult *origResult = [[CMHResult alloc] initWithResearchKitResult:CMHWrapperTestFactory.taskResult andStudyDescriptor:TestDescriptor];
         NSDictionary *encodedObjects = [CMObjectEncoder encodeObjects:@[origResult]];
         CMHResult *codedResult = [CMObjectDecoder decodeObjects:encodedObjects].firstObject;
 
         expect(codedResult == origResult).to.beFalsy();
-        expect([CMHResultTestFactory isEquivalent:(ORKTaskResult *)codedResult.rkResult]).to.beTruthy();
+        expect([CMHWrapperTestFactory isEquivalent:(ORKTaskResult *)codedResult.rkResult]).to.beTruthy();
         expect(codedResult.studyDescriptor).to.equal(TestDescriptor);
     });
 });

--- a/Example/Tests/CMHResultTests.m
+++ b/Example/Tests/CMHResultTests.m
@@ -58,6 +58,16 @@ describe(@"CMHResult", ^{
         expect([CMHResultTestFactory isEquivalent:(ORKTaskResult *)codedResult.rkResult]).to.beTruthy();
         expect(codedResult.studyDescriptor).to.equal(TestDescriptor);
     });
+
+    it(@"should encode and decode properly with CMCoder", ^{
+        CMHResult *origResult = [[CMHResult alloc] initWithResearchKitResult:CMHResultTestFactory.taskResult andStudyDescriptor:TestDescriptor];
+        NSDictionary *encodedObjects = [CMObjectEncoder encodeObjects:@[origResult]];
+        CMHResult *codedResult = [CMObjectDecoder decodeObjects:encodedObjects].firstObject;
+
+        expect(codedResult == origResult).to.beFalsy();
+        expect([CMHResultTestFactory isEquivalent:(ORKTaskResult *)codedResult.rkResult]).to.beTruthy();
+        expect(codedResult.studyDescriptor).to.equal(TestDescriptor);
+    });
 });
 
 SpecEnd

--- a/Example/Tests/CMHWrapperTestFactory.h
+++ b/Example/Tests/CMHWrapperTestFactory.h
@@ -1,0 +1,6 @@
+#import <ResearchKit/ResearchKit.h>
+
+@interface CMHWrapperTestFactory : NSObject
++ (ORKTaskResult *)taskResult;
++ (BOOL)isEquivalent:(ORKTaskResult *)taskResult;
+@end

--- a/Example/Tests/CMHWrapperTestFactory.m
+++ b/Example/Tests/CMHWrapperTestFactory.m
@@ -1,0 +1,32 @@
+#import "CMHWrapperTestFactory.h"
+
+@implementation CMHWrapperTestFactory
+
++ (ORKTaskResult *)taskResult
+{
+    ORKTextQuestionResult *textQuestionResult = [ORKTextQuestionResult new];
+    textQuestionResult.textAnswer = @"TestAnswer";
+
+    ORKScaleQuestionResult *scaleQuestionResult = [ORKScaleQuestionResult new];
+    scaleQuestionResult.scaleAnswer = [NSNumber numberWithFloat:1.16f];
+
+    ORKStepResult *stepResult = [[ORKStepResult alloc] initWithStepIdentifier:@"CMHTestStepIdentifier" results:@[textQuestionResult, scaleQuestionResult]];
+
+    ORKTaskResult *taskResult = [[ORKTaskResult alloc] initWithIdentifier:@"CMHTestIdentifier"];
+    taskResult.results = @[stepResult];
+
+    return taskResult;
+}
+
++ (BOOL)isEquivalent:(ORKTaskResult *)taskResult
+{
+    return [taskResult.identifier isEqualToString:@"CMHTestIdentifier"] &&
+    [taskResult.firstResult isKindOfClass:[ORKStepResult class]] &&
+    [taskResult.firstResult.identifier isEqualToString:@"CMHTestStepIdentifier"] &&
+    [((ORKStepResult *)taskResult.firstResult).results[0] isKindOfClass:[ORKTextQuestionResult class]] &&
+    [((ORKTextQuestionResult *)((ORKStepResult *)taskResult.firstResult).results[0]).textAnswer isEqualToString:@"TestAnswer"] &&
+    [((ORKStepResult *)taskResult.firstResult).results[1] isKindOfClass:[ORKScaleQuestionResult class]] &&
+    ((ORKScaleQuestionResult *)((ORKStepResult *)taskResult.firstResult).results[1]).scaleAnswer.floatValue == 1.16f;
+}
+
+@end

--- a/Pod/Classes/CMHInputValidators.m
+++ b/Pod/Classes/CMHInputValidators.m
@@ -23,9 +23,13 @@
         return NO;
     }
 
-    NSString *domainString = [possibleEmail componentsSeparatedByString:@"@"].lastObject;
-    NSRange dotRange = [domainString rangeOfString:@"."];
+    NSArray *atSplit = [possibleEmail componentsSeparatedByString:@"@"];
+    if (atSplit.count != 2) {
+        return NO;
+    }
 
+    NSString *domainString = atSplit.lastObject;
+    NSRange dotRange = [domainString rangeOfString:@"."];
     if (dotRange.location == NSNotFound || dotRange.location == 0 || dotRange.location == domainString.length - 1) {
         return NO;
     }


### PR DESCRIPTION
Add unit tests for critical/logic heavy code paths. This includes tests for internal and external API. Tests for internals are epmloyed when those internals maintain some state that manifests in the public API in the form of behavior, even if the methods are not explicitly exposed. Also includes a small but in email validation uncovered by writing the tests.