### PR TITLE
Delete Data Generated During Integration Tests

### DIFF
--- a/Example/CMHealth.xcodeproj/project.pbxproj
+++ b/Example/CMHealth.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		B447ED641C926FC100DC6208 /* CMHWrapperTestFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = B447ED631C926FC100DC6208 /* CMHWrapperTestFactory.m */; };
 		B447ED661C92710400DC6208 /* CMHConsentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B447ED651C92710400DC6208 /* CMHConsentTests.m */; };
 		B447ED681C98755500DC6208 /* Test-Consent-PDF.pdf in Resources */ = {isa = PBXBuildFile; fileRef = B447ED671C98755500DC6208 /* Test-Consent-PDF.pdf */; };
+		B447ED6B1C98A01D00DC6208 /* CMHTestCleaner.m in Sources */ = {isa = PBXBuildFile; fileRef = B447ED6A1C98A01D00DC6208 /* CMHTestCleaner.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -81,6 +82,8 @@
 		B447ED631C926FC100DC6208 /* CMHWrapperTestFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMHWrapperTestFactory.m; sourceTree = "<group>"; };
 		B447ED651C92710400DC6208 /* CMHConsentTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMHConsentTests.m; sourceTree = "<group>"; };
 		B447ED671C98755500DC6208 /* Test-Consent-PDF.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = "Test-Consent-PDF.pdf"; sourceTree = "<group>"; };
+		B447ED691C98A01D00DC6208 /* CMHTestCleaner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CMHTestCleaner.h; sourceTree = "<group>"; };
+		B447ED6A1C98A01D00DC6208 /* CMHTestCleaner.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMHTestCleaner.m; sourceTree = "<group>"; };
 		F0A86E2796A10F23CD8FFB5E /* Pods_CMHealth_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CMHealth_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FEB06221139C06DAA962E0A6 /* Pods-CMHealth_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CMHealth_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-CMHealth_Tests/Pods-CMHealth_Tests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -192,6 +195,8 @@
 			children = (
 				B447ED621C926FC100DC6208 /* CMHWrapperTestFactory.h */,
 				B447ED631C926FC100DC6208 /* CMHWrapperTestFactory.m */,
+				B447ED691C98A01D00DC6208 /* CMHTestCleaner.h */,
+				B447ED6A1C98A01D00DC6208 /* CMHTestCleaner.m */,
 				B447ED4E1C8DED1500DC6208 /* CMHTest-Secrets.h */,
 				6003F5B7195388D20070C39A /* Tests-Info.plist */,
 				6003F5B8195388D20070C39A /* InfoPlist.strings */,
@@ -433,6 +438,7 @@
 				B447ED661C92710400DC6208 /* CMHConsentTests.m in Sources */,
 				B447ED641C926FC100DC6208 /* CMHWrapperTestFactory.m in Sources */,
 				B447ED5D1C91F8C000DC6208 /* CMHErrorUtilitiesTests.m in Sources */,
+				B447ED6B1C98A01D00DC6208 /* CMHTestCleaner.m in Sources */,
 				B447ED591C8F772800DC6208 /* CMHConsentValidatorTests.m in Sources */,
 				B447ED611C9220E200DC6208 /* CMHResultTests.m in Sources */,
 				6003F5BC195388D20070C39A /* CMHIntegrationTests.m in Sources */,

--- a/Example/Tests/CMHIntegrationTests.m
+++ b/Example/Tests/CMHIntegrationTests.m
@@ -338,7 +338,7 @@ describe(@"CMHealthIntegration", ^{
     afterAll(^{
          waitUntil(^(DoneCallback done) {
              CMHTestCleaner *cleaner = [CMHTestCleaner new];
-             [cleaner deleteConsent:consentToClean andResultsWithDescriptor:TestDescriptor withCompletion:^(NSArray *errors) {
+             [cleaner deleteConsent:consentToClean andResultsWithDescriptor:TestDescriptor withCompletion:^ {
                  done();
              }];
          });

--- a/Example/Tests/CMHIntegrationTests.m
+++ b/Example/Tests/CMHIntegrationTests.m
@@ -338,7 +338,7 @@ describe(@"CMHealthIntegration", ^{
     afterAll(^{
          waitUntil(^(DoneCallback done) {
              CMHTestCleaner *cleaner = [CMHTestCleaner new];
-             [cleaner deleteConsent:consentToClean andResultsWithDescriptor:@"" withCompletion:^(NSArray *errors) {
+             [cleaner deleteConsent:consentToClean andResultsWithDescriptor:TestDescriptor withCompletion:^(NSArray *errors) {
                  done();
              }];
          });

--- a/Example/Tests/CMHIntegrationTests.m
+++ b/Example/Tests/CMHIntegrationTests.m
@@ -1,5 +1,6 @@
 #import <CMHealth/CMHealth.h>
 #import "CMHTest-Secrets.h"
+#import "CMHTestCleaner.h"
 
 static NSString *const TestDescriptor = @"CMHTestDescriptor";
 static NSString *const TestPassword   = @"test-paSsword1!";
@@ -9,6 +10,7 @@ static NSString *const TestFamilyName = @"Doe";
 SpecBegin(CMHealthIntegration)
 
 describe(@"CMHealthIntegration", ^{
+    __block CMHConsent *consentToClean = nil;
 
     beforeAll(^{
         NSString *assertionError = @"You haven't set valid credentials in CMHTest-Secrets.h";
@@ -72,6 +74,8 @@ describe(@"CMHealthIntegration", ^{
                 done();
             }];
         });
+
+        consentToClean = returnConsent;
 
         expect(uploadError).to.beNil();
         expect(returnConsent.consentResult).to.equal(consentResult);
@@ -329,6 +333,15 @@ describe(@"CMHealthIntegration", ^{
 
     it(@"should pass", ^{
         expect(YES).to.beTruthy();
+    });
+
+    afterAll(^{
+         waitUntil(^(DoneCallback done) {
+             CMHTestCleaner *cleaner = [CMHTestCleaner new];
+             [cleaner deleteConsent:consentToClean andResultsWithDescriptor:@"" withCompletion:^(NSArray *errors) {
+                 done();
+             }];
+         });
     });
 });
 

--- a/Example/Tests/CMHTestCleaner.h
+++ b/Example/Tests/CMHTestCleaner.h
@@ -1,0 +1,11 @@
+#import <CloudMine/CloudMine.h>
+#import <ResearchKit/ResearchKit.h>
+#import <CMHealth/CMHealth.h>
+
+typedef void(^CMHCleanupCompletion)(NSArray <NSError *> *_Nonnull);
+
+@interface CMHTestCleaner : NSObject
+
+- (void)deleteConsent:(CMHConsent *_Nullable)consent andResultsWithDescriptor:(NSString *_Nullable)descriptor withCompletion:(_Nonnull CMHCleanupCompletion)block;
+
+@end

--- a/Example/Tests/CMHTestCleaner.h
+++ b/Example/Tests/CMHTestCleaner.h
@@ -2,10 +2,8 @@
 #import <ResearchKit/ResearchKit.h>
 #import <CMHealth/CMHealth.h>
 
-typedef void(^CMHCleanupCompletion)(NSArray <NSError *> *_Nonnull);
-
 @interface CMHTestCleaner : NSObject
 
-- (void)deleteConsent:(CMHConsent *_Nullable)consent andResultsWithDescriptor:(NSString *_Nullable)descriptor withCompletion:(_Nonnull CMHCleanupCompletion)block;
+- (void)deleteConsent:(CMHConsent *_Nullable)consent andResultsWithDescriptor:(NSString *_Nullable)descriptor withCompletion:(void (^_Nonnull)())block;
 
 @end

--- a/Example/Tests/CMHTestCleaner.m
+++ b/Example/Tests/CMHTestCleaner.m
@@ -5,9 +5,7 @@
 @interface CMHTestCleaner ()
 @property (nonatomic, nonnull) NSMutableArray<CMObject *> *objects;
 @property (nonatomic, nonnull) NSMutableArray<NSString *> *filenames;
-
 @property (nonatomic, nonnull) NSMutableArray<CMObject *> *failedObjects;
-@property (nonatomic, nonnull) NSMutableArray<NSError *> *errors;
 @end
 
 @implementation CMHTestCleaner
@@ -19,12 +17,11 @@
 
     self.objects = [NSMutableArray new];
     self.filenames = [NSMutableArray new];
-    self.errors = [NSMutableArray new];
 
     return self;
 }
 
-- (void)deleteConsent:(CMHConsent *)consent andResultsWithDescriptor:(NSString *)descriptor withCompletion:(CMHCleanupCompletion)block
+- (void)deleteConsent:(CMHConsent *)consent andResultsWithDescriptor:(NSString *)descriptor withCompletion:(void (^)())block
 {
     [self.objects addObject:consent];
 
@@ -40,28 +37,10 @@
     }];
 }
 
-- (void)pushObject:(CMObject *)object
-{
-    if (nil == object) {
-        return;
-    }
-
-    [self.objects addObject:object];
-}
-
-- (void)pushFileNamed:(NSString *)filename
-{
-    if (nil == filename) {
-        return;
-    }
-
-    [self.filenames addObject:filename];
-}
-
-- (void)deleteAllObjectsAndFilesWithCompletion:(_Nonnull CMHCleanupCompletion)block
+- (void)deleteAllObjectsAndFilesWithCompletion:(void (^)())block
 {
     [self deleteAllObjectsWithCompletion:^{
-        block([self.errors copy]);
+        block();
     }];
 }
 
@@ -76,10 +55,8 @@
 
     [[CMStore defaultStore] deleteUserObject:object additionalOptions:nil callback:^(CMDeleteResponse *response) {
         if (nil != response.error) {
-            [self.errors addObject:response.error];
             [self.failedObjects addObject:object];
         } else if (nil != response.objectErrors[object.objectId]) {
-            [self.errors addObject:response.objectErrors[object.objectId]];
             [self.failedObjects addObject:object];
         }
 

--- a/Example/Tests/CMHTestCleaner.m
+++ b/Example/Tests/CMHTestCleaner.m
@@ -1,0 +1,79 @@
+#import "CMHTestCleaner.h"
+
+@interface CMHTestCleaner ()
+@property (nonatomic, nonnull) NSMutableArray<CMObject *> *objects;
+@property (nonatomic, nonnull) NSMutableArray<NSString *> *filenames;
+
+@property (nonatomic, nonnull) NSMutableArray<CMObject *> *failedObjects;
+@property (nonatomic, nonnull) NSMutableArray<NSError *> *errors;
+@end
+
+@implementation CMHTestCleaner
+
+- (instancetype)init
+{
+    self = [super init];
+    if (nil == self) return nil;
+
+    self.objects = [NSMutableArray new];
+    self.filenames = [NSMutableArray new];
+    self.errors = [NSMutableArray new];
+
+    return self;
+}
+
+-(void)deleteConsent:(CMHConsent *)consent andResultsWithDescriptor:(NSString *)descriptor withCompletion:(CMHCleanupCompletion)block
+{
+    [self.objects addObject:consent];
+    [self deleteAllObjectsAndFilesWithCompletion:block];
+}
+
+- (void)pushObject:(CMObject *)object
+{
+    if (nil == object) {
+        return;
+    }
+
+    [self.objects addObject:object];
+}
+
+- (void)pushFileNamed:(NSString *)filename
+{
+    if (nil == filename) {
+        return;
+    }
+
+    [self.filenames addObject:filename];
+}
+
+- (void)deleteAllObjectsAndFilesWithCompletion:(_Nonnull CMHCleanupCompletion)block
+{
+    [self deleteAllObjectsWithCompletion:^{
+        block([self.errors copy]);
+    }];
+}
+
+- (void)deleteAllObjectsWithCompletion:(void (^)())block
+{
+    if (self.objects.count <= 0) {
+        block();
+        return;
+    }
+
+    CMObject *object = self.objects.firstObject;
+
+    [[CMStore defaultStore] deleteUserObject:object additionalOptions:nil callback:^(CMDeleteResponse *response) {
+        if (nil != response.error) {
+            [self.errors addObject:response.error];
+            [self.failedObjects addObject:object];
+        } else if (nil != response.objectErrors[object.objectId]) {
+            [self.errors addObject:response.objectErrors[object.objectId]];
+            [self.failedObjects addObject:object];
+        }
+
+        [self.objects removeObject:object];
+        [self deleteAllObjectsWithCompletion:block];
+    }];
+}
+
+@end


### PR DESCRIPTION
Add a standalone class that cleans up data generated by the execution of the Integration tests. All objects and files are removed. User accounts do remain, at the moment.