### PR TITLE
Identifier Fetch Methods

### DIFF
--- a/Example/Tests/CMHIntegrationTests.m
+++ b/Example/Tests/CMHIntegrationTests.m
@@ -276,6 +276,26 @@ describe(@"CMHealthIntegration", ^{
         expect(statusTwo).to.equal(@"created");
     });
 
+    it(@"should properly fetch uploaded results by their research kit identifier property", ^{
+        __block NSArray *fetchResults = nil;
+        __block NSError *fetchError = nil;
+
+        waitUntil(^(DoneCallback done) {
+            [ORKStepResult cmh_fetchUserResultsForStudyWithDescriptor:TestDescriptor andIdentifier:@"StepTestOneIdentifier" withCompletion:^(NSArray *results, NSError *error) {
+                fetchResults = results;
+                fetchError = error;
+                done();
+            }];
+        });
+
+        expect(fetchError).to.beNil();
+        expect(fetchResults.count).to.equal(1);
+
+        ORKTextQuestionResult *questionResult = (ORKTextQuestionResult *)((ORKStepResult *)fetchResults.firstObject).firstResult;
+
+        expect(questionResult.textAnswer).to.equal(@"StepOne");
+    });
+
     it(@"should properly query uploaded results", ^{
         __block NSArray *fetchResults = nil;
         __block NSError *fetchError = nil;

--- a/Pod/Classes/ORKResult+CMHealth.h
+++ b/Pod/Classes/ORKResult+CMHealth.h
@@ -50,9 +50,25 @@ typedef void(^CMHFetchCompletion)(NSArray *_Nullable results, NSError *_Nullable
 + (void)cmh_fetchUserResultsForStudyWithDescriptor:(NSString *_Nullable)descriptor
                                     withCompletion:(_Nullable CMHFetchCompletion)block;
 
+/**
+ *  Convenience method for fetching results by ResearchKit identifier with an empty
+ *  study descriptor.
+ *
+ *  @see + cmh_fetchUserResultsForStudyWithDescriptor:andIdentifier:withCompletion:
+ */
 + (void)cmh_fetchUserResultsForStudyWithIdentifier:(NSString *_Nullable)identifier
                                     withCompletion:(_Nullable CMHFetchCompletion)block;
 
+/**
+ *  Fetch all results of the calling class, for the study with a given descriptor,
+ *  where the top level object has the given identifier.
+ *
+ *  @warning Calling this method includes an implicit filter for the class of the caller.
+ *
+ *  @param descriptor The descriptor of the study for which results are desired.
+ *  @param identifier The ResearchKit identifier property of the top level result desired.
+ *  @param block Executes when the request succeeds or fails with an error.
+ */
 + (void)cmh_fetchUserResultsForStudyWithDescriptor:(NSString *_Nullable)descriptor
                                      andIdentifier:(NSString *_Nullable)identifier
                                     withCompletion:(_Nullable CMHFetchCompletion)block;

--- a/Pod/Classes/ORKResult+CMHealth.h
+++ b/Pod/Classes/ORKResult+CMHealth.h
@@ -50,6 +50,13 @@ typedef void(^CMHFetchCompletion)(NSArray *_Nullable results, NSError *_Nullable
 + (void)cmh_fetchUserResultsForStudyWithDescriptor:(NSString *_Nullable)descriptor
                                     withCompletion:(_Nullable CMHFetchCompletion)block;
 
++ (void)cmh_fetchUserResultsForStudyWithIdentifier:(NSString *_Nullable)identifier
+                                    withCompletion:(_Nullable CMHFetchCompletion)block;
+
++ (void)cmh_fetchUserResultsForStudyWithDescriptor:(NSString *_Nullable)descriptor
+                                     andIdentifier:(NSString *_Nullable)identifier
+                                    withCompletion:(_Nullable CMHFetchCompletion)block;
+
 /**
  *  Convenience method for querying results with an empty study descriptor.
  *

--- a/Pod/Classes/ORKResult+CMHealth.m
+++ b/Pod/Classes/ORKResult+CMHealth.m
@@ -45,6 +45,21 @@
     [self cmh_fetchUserResultsForStudyWithDescriptor:descriptor andQuery:nil withCompletion:block];
 }
 
++ (void)cmh_fetchUserResultsForStudyWithIdentifier:(NSString *_Nullable)identifier withCompletion:(_Nullable CMHFetchCompletion)block
+{
+    [self cmh_fetchUserResultsForStudyWithDescriptor:nil andIdentifier:identifier withCompletion:block];
+}
+
++ (void)cmh_fetchUserResultsForStudyWithDescriptor:(NSString *_Nullable)descriptor andIdentifier:(NSString *_Nullable)identifier withCompletion:(_Nullable CMHFetchCompletion)block
+{
+    NSString *query = nil;
+    if (nil != identifier) {
+        query = [NSString stringWithFormat:@"[identifier = \"%@\"]", identifier];
+    }
+
+    [self cmh_fetchUserResultsForStudyWithDescriptor:descriptor andQuery:query withCompletion:block];
+}
+
 + (void)cmh_fetchUserResultsForStudyWithQuery:(NSString *_Nullable)query
                                withCompletion:(_Nullable CMHFetchCompletion)block
 {


### PR DESCRIPTION
Provides two convenience methods for fetching `ORKResult` objects based on their ResearchKit identifier property. Internally, these curry to other methods. Includes integration tests and documentation.