### PR TITLE
Fetch the user profile object if the user is logged

### DIFF
--- a/Pod/Classes/CMHErrorUtilities.m
+++ b/Pod/Classes/CMHErrorUtilities.m
@@ -53,14 +53,15 @@
         kind = @"file";
     }
 
-    NSError *responseError = response.error;
+    NSString *responseErrorMessage = response.error.localizedDescription;
 
-    if (nil == responseError) {
-        responseError = response.objectErrors[response.objectErrors.allKeys.firstObject];
+    if (nil == responseErrorMessage) {
+        // objectErrors is a dictionary of dictionarys with keys: @"code" and @"message"
+        responseErrorMessage = response.objectErrors[response.objectErrors.allKeys.firstObject][@"message"];
     }
 
-    if (nil != responseError) {
-        NSString *message = [NSString localizedStringWithFormat:@"Failed to fetch %@; %@", kind,  responseError.localizedDescription];
+    if (nil != responseErrorMessage) {
+        NSString *message = [NSString localizedStringWithFormat:@"Failed to fetch %@; %@", kind,  responseErrorMessage];
         return [self errorWithCode:CMHErrorFailedToFetchObject localizedDescription:message];
     }
 

--- a/Pod/Classes/CMHInternalUser.h
+++ b/Pod/Classes/CMHInternalUser.h
@@ -8,6 +8,7 @@
 + (void)signUpWithEmail:(NSString *)email password:(NSString *)password andCompletion:(CMHUserAuthCompletion)block;
 + (void)loginAndLoadProfileWithEmail:(NSString *)email password:(NSString *)password andCompletion:(CMHUserAuthCompletion)block;
 
+- (void)loadProfileWithCompletion:(CMHUserAuthCompletion)block;
 - (void)updateFamilyName:(NSString *)familyName givenName:(NSString *)givenName withCompletion:(CMHUserAuthCompletion)block;
 - (CMHUserData *)generateCurrentUserData;
 

--- a/Pod/Classes/CMHUser.m
+++ b/Pod/Classes/CMHUser.m
@@ -24,20 +24,18 @@
     dispatch_once(&oncePredicate, ^{
         _sharedInstance = [CMHUser new];
         _sharedInstance.userData = [CMHInternalUser.currentUser generateCurrentUserData];
-
-        // Need to think more carefully about this. It probably doesn't belong here, but I think
-        // a goal should be to hide the sense of a "store" from the SDK consumer. We need to perform
-        // this side effect somewhere, but where?
         [CMStore defaultStore].user = [CMHInternalUser currentUser];
     });
 
     if (nil == _sharedInstance.userData && _sharedInstance.isLoggedIn) {
-        [CMHInternalUser.currentUser loadProfileWithCompletion:nil];
-    }
+        [CMHInternalUser.currentUser loadProfileWithCompletion:^(NSError * _Nullable error) {
+            if (nil != error) {
+                return;
+            }
 
-    //if (_sharedInstance.isLoggedIn && nil == _sharedInstance.userData) {
-        //[CMHInternalUser.currentUser loadProfileWithCompletion:nil];
-    //}
+            _sharedInstance.userData = [CMHInternalUser.currentUser generateCurrentUserData];
+        }];
+    }
 
     return _sharedInstance;
 }

--- a/Pod/Classes/CMHUser.m
+++ b/Pod/Classes/CMHUser.m
@@ -31,6 +31,14 @@
         [CMStore defaultStore].user = [CMHInternalUser currentUser];
     });
 
+    if (nil == _sharedInstance.userData && _sharedInstance.isLoggedIn) {
+        [CMHInternalUser.currentUser loadProfileWithCompletion:nil];
+    }
+
+    //if (_sharedInstance.isLoggedIn && nil == _sharedInstance.userData) {
+        //[CMHInternalUser.currentUser loadProfileWithCompletion:nil];
+    //}
+
     return _sharedInstance;
 }
 

--- a/Pod/Classes/ORKResult+CMHealth.m
+++ b/Pod/Classes/ORKResult+CMHealth.m
@@ -120,10 +120,12 @@
     // Note: an error with any result will cause an error for the whole fetch.
     // This decision keeps the API simple, but is there a compelling reason why
     // we wouldn't want this?
-    NSError *objectInternalError = response.objectErrors[response.objectErrors.allKeys.firstObject];
-    if(nil != objectInternalError) {
-        NSString *objectErrorPrefix = [NSString localizedStringWithFormat:@"%@; there was an error with at least one object (key: %@)", errorPrefix, response.objectErrors.allKeys.firstObject];
-        return [self errorForInternalError:objectInternalError withPrefix:objectErrorPrefix];
+    NSString *objectInternalErrorMessage = response.objectErrors[response.objectErrors.allKeys.firstObject][@"message"];
+    NSString *errorKey = response.objectErrors.allKeys.firstObject;
+
+    if(nil != objectInternalErrorMessage) {
+        NSString *objectErrorMessage = [NSString localizedStringWithFormat:@"%@; there was an error with at least one object: %@ (key: %@)", errorPrefix, objectInternalErrorMessage, errorKey];
+        return [CMHErrorUtilities errorWithCode:CMHErrorUnknown localizedDescription:objectErrorMessage];
     }
 
     return nil;


### PR DESCRIPTION
If the user is logged in, but the profile is not currently present, we'll fetch it quietly in the background. Since the profile data is fetched as part of signup and login, the most common scenario for when this occurs would be when the app exits memory and then is relaunched.

We could have considered a local caching approach, but then we need a syncing strategy as well. This makes KVO the ideal way to handle `userData` changes.