### PR TITLE
Support for serialization of `ORKDateQuestionResult`s

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -32,7 +32,7 @@ PODS:
   - Expecta (1.0.5)
   - ResearchKit (1.3.0)
   - Specta (1.0.5)
-  - TPKeyboardAvoiding (1.2.11)
+  - TPKeyboardAvoiding (1.3)
 
 DEPENDENCIES:
   - CMHealth (from `../`)
@@ -50,6 +50,6 @@ SPEC CHECKSUMS:
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   ResearchKit: 934a1efefed1a3a9150002a1e4b123d0c86c3f2e
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
-  TPKeyboardAvoiding: e5ce146b313de063957bfa75a13f1e9b0ff18ab7
+  TPKeyboardAvoiding: a5138f318c06fb3e151f886e18ce4a72695d9cbe
 
 COCOAPODS: 0.39.0

--- a/Example/Tests/CMHCocoaCategoryTests.m
+++ b/Example/Tests/CMHCocoaCategoryTests.m
@@ -4,8 +4,12 @@
 
 @interface CMHTestCodingWrapper : CMObject
 - (instancetype)initWithUUID:(NSUUID *)uuid;
+- (instancetype)initWithImage:(UIImage *)image;
 @property (nonatomic) NSUUID *uuid;
 @property (nonatomic) UIImage *image;
+@property (nonatomic) NSCalendar *calendar;
+@property (nonatomic) NSTimeZone *timeZone;
+@property (nonatomic) NSLocale *locale;
 @end
 
 @implementation CMHTestCodingWrapper
@@ -37,6 +41,9 @@
 
     self.uuid = [aDecoder decodeObjectForKey:@"uuid"];
     self.image = [aDecoder decodeObjectForKey:@"image"];
+    self.calendar = [aDecoder decodeObjectForKey:@"calendar"];
+    self.timeZone = [aDecoder decodeObjectForKey:@"timeZone"];
+    self.locale = [aDecoder decodeObjectForKey:@"locale"];
 
     return self;
 }
@@ -46,6 +53,9 @@
     [super encodeWithCoder:aCoder];
     [aCoder encodeObject:self.uuid forKey:@"uuid"];
     [aCoder encodeObject:self.image forKey:@"image"];
+    [aCoder encodeObject:self.calendar forKey:@"calendar"];
+    [aCoder encodeObject:self.timeZone forKey:@"timeZone"];
+    [aCoder encodeObject:self.locale forKey:@"locale"];
 }
 
 @end
@@ -99,5 +109,74 @@ describe(@"UIImage", ^{
     });
 });
 
+describe(@"NSCalendar", ^{
+    it(@"should encode and decode properly with NSCoder", ^{
+        NSCalendar *origCalendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierChinese];
+        NSData *calendarData = [NSKeyedArchiver archivedDataWithRootObject:origCalendar];
+        NSCalendar *codedCalendar = [NSKeyedUnarchiver unarchiveObjectWithData:calendarData];
+
+        expect(origCalendar == codedCalendar).to.beFalsy();
+        expect(origCalendar.calendarIdentifier == codedCalendar.calendarIdentifier).to.beTruthy();
+        expect(origCalendar).to.equal(codedCalendar);
+    });
+
+    it(@"should encode and decode properly with CMCoder", ^{
+        CMHTestCodingWrapper *origWrapper = [CMHTestCodingWrapper new];
+        origWrapper.calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierChinese];
+        NSDictionary *encodedObjects = [CMObjectEncoder encodeObjects:@[origWrapper]];
+        CMHTestCodingWrapper *codedWrapper = [CMObjectDecoder decodeObjects:encodedObjects].firstObject;
+
+        expect(origWrapper == codedWrapper).to.beFalsy();
+        expect(origWrapper.calendar == codedWrapper.calendar).to.beFalsy();
+        expect([codedWrapper.calendar.calendarIdentifier isEqualToString:origWrapper.calendar.calendarIdentifier]).to.beTruthy();
+        expect(origWrapper.calendar).to.equal(codedWrapper.calendar);
+    });
+});
+
+describe(@"NSTimeZone", ^{
+    it(@"should encode and decode properly with NSCoder", ^{
+        NSTimeZone *origZone = [NSTimeZone timeZoneWithName:@"Pacific/Honolulu"];
+        NSData *zoneData = [NSKeyedArchiver archivedDataWithRootObject:origZone];
+        NSTimeZone *codedZone = [NSKeyedUnarchiver unarchiveObjectWithData:zoneData];
+
+        expect(origZone == codedZone).to.beFalsy();
+        expect([origZone.name isEqualToString:codedZone.name]).to.beTruthy();
+        expect(origZone).to.equal(codedZone);
+    });
+
+    it(@"should encode and decode properly with CMCoder", ^{
+        CMHTestCodingWrapper *origWrapper = [CMHTestCodingWrapper new];
+        origWrapper.timeZone = [NSTimeZone timeZoneWithName:@"Pacific/Honolulu"];
+        NSDictionary *encodedObjects = [CMObjectEncoder encodeObjects:@[origWrapper]];
+        CMHTestCodingWrapper *codedWrapper = [CMObjectDecoder decodeObjects:encodedObjects].firstObject;
+
+        expect(origWrapper == codedWrapper).to.beFalsy();
+        expect(origWrapper.timeZone == codedWrapper.timeZone).to.beFalsy();
+        expect([origWrapper.timeZone.name isEqualToString:codedWrapper.timeZone.name]).to.beTruthy();
+        expect(origWrapper.timeZone).to.equal(codedWrapper.timeZone);
+    });
+});
+
+describe(@"NSLocale", ^{
+    it(@"should encode and decode properly with NSCoder", ^{
+        NSLocale *origLocale = [NSLocale localeWithLocaleIdentifier:[NSLocale canonicalLocaleIdentifierFromString:@"it_IT"]];
+        NSData *localeData = [NSKeyedArchiver archivedDataWithRootObject:origLocale];
+        NSLocale *codedLocale = [NSKeyedUnarchiver unarchiveObjectWithData:localeData];
+
+        expect(origLocale).notTo.beNil();
+        expect([origLocale.localeIdentifier isEqualToString:codedLocale.localeIdentifier]).to.beTruthy();
+        expect(origLocale).to.equal(codedLocale);
+    });
+
+    it(@"should econde and decode properly with CMCoder", ^{
+        CMHTestCodingWrapper *origWrapper = [CMHTestCodingWrapper new];
+        origWrapper.locale = [NSLocale localeWithLocaleIdentifier:[NSLocale canonicalLocaleIdentifierFromString:@"it_IT"]];
+        NSDictionary *encodedObjects = [CMObjectEncoder encodeObjects:@[origWrapper]];
+        CMHTestCodingWrapper *codedWrapper = [CMObjectDecoder decodeObjects:encodedObjects].firstObject;
+
+        expect(origWrapper == codedWrapper).to.beFalsy();
+        expect([origWrapper.locale.localeIdentifier isEqualToString:codedWrapper.locale.localeIdentifier]).to.beTruthy();
+    });
+});
 
 SpecEnd

--- a/Example/Tests/CMHIntegrationTests.m
+++ b/Example/Tests/CMHIntegrationTests.m
@@ -183,7 +183,12 @@ describe(@"CMHealthIntegration", ^{
         ORKBooleanQuestionResult *booleanResult = [ORKBooleanQuestionResult new];
         booleanResult.booleanAnswer = [NSNumber numberWithBool:YES];
 
-        taskResult.results = @[scaleResult, booleanResult];
+        ORKDateQuestionResult *dateResult = [ORKDateQuestionResult new];
+        dateResult.dateAnswer = [NSDate dateWithTimeIntervalSince1970:127.0];
+        dateResult.calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierChinese];
+        dateResult.timeZone = [NSTimeZone timeZoneWithName:@"Pacific/Honolulu"];
+
+        taskResult.results = @[scaleResult, booleanResult, dateResult];
 
         __block NSString *uploadStatus = nil;
         __block NSError *uploadError = nil;
@@ -223,6 +228,12 @@ describe(@"CMHealthIntegration", ^{
 
         expect([task.results[1] class]).to.equal([ORKBooleanQuestionResult class]);
         expect(((ORKBooleanQuestionResult *)task.results[1]).booleanAnswer.boolValue).to.equal(YES);
+
+        expect([task.results[2] class]).to.equal([ORKDateQuestionResult class]);
+        ORKDateQuestionResult *dateResult = (ORKDateQuestionResult *)task.results[2];
+        expect(dateResult.dateAnswer.timeIntervalSince1970).to.equal(127.0);
+        expect(dateResult.calendar).to.equal([NSCalendar calendarWithIdentifier:NSCalendarIdentifierChinese]);
+        expect(dateResult.timeZone).to.equal([NSTimeZone timeZoneWithName:@"Pacific/Honolulu"]);
     });
 
     it(@"should return emptry results for an unused descriptor", ^{

--- a/Pod/Classes/Cocoa+CMHealth.h
+++ b/Pod/Classes/Cocoa+CMHealth.h
@@ -6,3 +6,12 @@
 
 @interface NSUUID (CMHealth)<CMCoding>
 @end
+
+@interface NSCalendar (CMHealth)<CMCoding>
+@end
+
+@interface NSTimeZone (CMHealth)<CMCoding>
+@end
+
+@interface NSLocale (CMHealth)<CMCoding>
+@end

--- a/Pod/Classes/Cocoa+CMHealth.m
+++ b/Pod/Classes/Cocoa+CMHealth.m
@@ -73,3 +73,78 @@ void cmh_swizzle(Class class, SEL originalSelector, SEL swizzledSelector)
 }
 
 @end
+
+@implementation NSCalendar (CMHealth)
+
++ (void)load {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        cmh_swizzle([self class], @selector(initWithCoder:), @selector(initWithCoder_cmh:));
+        cmh_swizzle([self class], @selector(encodeWithCoder:), @selector(cmh_encodeWithCoder:));
+    });
+}
+
+- (void)cmh_encodeWithCoder:(NSCoder *)aCoder
+{
+    if ([aCoder isKindOfClass:[CMObjectEncoder class]]) {   
+        [aCoder encodeObject:self.calendarIdentifier forKey:@"calendarIdentifier"];
+        [aCoder encodeObject:self.locale forKey:@"locale"];
+        [aCoder encodeObject:self.timeZone forKey:@"timeZone"];
+        [aCoder encodeInteger:self.firstWeekday forKey:@"firstWeekday"];
+        [aCoder encodeInteger:self.minimumDaysInFirstWeek forKey:@"minimumDaysInFirstWeek"];
+        return;
+    }
+
+    [self cmh_encodeWithCoder:aCoder];
+}
+
+- (instancetype)initWithCoder_cmh:(NSCoder *)decoder
+{
+    if ([decoder isKindOfClass:[CMObjectDecoder class]]) {
+        self = [[NSCalendar alloc] initWithCalendarIdentifier:[decoder decodeObjectForKey:@"calendarIdentifier"]];
+        self.locale = [decoder decodeObjectForKey:@"locale"];
+        self.timeZone = [decoder decodeObjectForKey:@"timeZone"];
+        self.firstWeekday = [decoder decodeIntegerForKey:@"firstWeekday"];
+        self.minimumDaysInFirstWeek = [decoder decodeIntegerForKey:@"minimumDaysInFirstWeek"];
+        return self;
+    }
+
+    return [self initWithCoder_cmh:decoder];
+}
+
+@end
+
+@implementation NSTimeZone (CMHealth)
+
++ (void)load {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        cmh_swizzle([self class], @selector(initWithCoder:), @selector(initWithCoder_cmh:));
+        cmh_swizzle([self class], @selector(encodeWithCoder:), @selector(cmh_encodeWithCoder:));
+    });
+}
+
+- (void)cmh_encodeWithCoder:(NSCoder *)aCoder
+{
+    if ([aCoder isKindOfClass:[CMObjectEncoder class]]) {
+        [aCoder encodeObject:self.name forKey:@"name"];
+        return;
+    }
+
+    [self cmh_encodeWithCoder:aCoder];
+}
+
+- (instancetype)initWithCoder_cmh:(NSCoder *)decoder
+{
+    if ([decoder isKindOfClass:[CMObjectDecoder class]]) {
+        self = [NSTimeZone timeZoneWithName:[decoder decodeObjectForKey:@"name"]];
+        return self;
+    }
+
+    return [self initWithCoder_cmh:decoder];
+}
+
+@end
+
+@implementation NSLocale (CMHealth)
+@end


### PR DESCRIPTION
Per #66, saving of `ORKDateQuestionResult`s was broken in the SDK. The reason for this is that these objects contain non-primitive properties, namely:

 * `NSTimeZone`
 * `NSCalendar`
  * `NSLocale` (property of `NSCalendar`)

This PR resolves this by implementing and overriding the serialization of these types when using a `CMObjectEncoder` or `CMObjectDecoder`. Unit and integration tests are also included.