### PR TITLE
Support for serialization of ORKTimeOfDayQuestionResult

### DIFF
--- a/Example/Tests/CMHCocoaCategoryTests.m
+++ b/Example/Tests/CMHCocoaCategoryTests.m
@@ -1,6 +1,7 @@
 #import <Foundation/Foundation.h>
 #import <CMHealth/Cocoa+CMHealth.h>
 #import <CloudMine/CloudMine.h>
+#import "CMHWrapperTestFactory.h"
 
 @interface CMHTestCodingWrapper : CMObject
 - (instancetype)initWithUUID:(NSUUID *)uuid;
@@ -59,58 +60,6 @@
     [aCoder encodeObject:self.timeZone forKey:@"timeZone"];
     [aCoder encodeObject:self.locale forKey:@"locale"];
     [aCoder encodeObject:self.comps forKey:@"comps"];
-}
-
-#pragma mark Factory Convenience Methods
-
-+ (NSDateComponents *)testDateComponents
-{
-    NSDateComponents *comps = [NSDateComponents new];
-    comps.calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierHebrew];
-    comps.timeZone = [NSTimeZone timeZoneWithName:@"Pacific/Honolulu"];
-    comps.era = 1;
-    comps.year = 5000;
-    comps.month = 10;
-    comps.day = 12;
-    comps.hour = 7;
-    comps.minute = 16;
-    comps.second = 6;
-    comps.nanosecond = 4;
-    comps.weekday = 3;
-    comps.weekdayOrdinal = 2;
-    comps.quarter = 2;
-    comps.weekOfMonth = 1;
-    comps.weekOfYear = 40;
-    comps.yearForWeekOfYear = 8;
-    comps.leapMonth = NO;
-
-    return comps;
-}
-
-+ (BOOL)isEquivalentToTest:(NSDateComponents *)comps
-{
-    NSDateComponents *testComps = [self testDateComponents];
-
-    BOOL isEqual = YES;
-    isEqual = isEqual && [comps.calendar.calendarIdentifier isEqualToString:testComps.calendar.calendarIdentifier];
-    isEqual = isEqual && [comps.timeZone.name isEqualToString:testComps.timeZone.name];
-    isEqual = isEqual && comps.era == testComps.era;
-    isEqual = isEqual && comps.year == testComps.year;
-    isEqual = isEqual && comps.month == testComps.month;
-    isEqual = isEqual && comps.day == testComps.day;
-    isEqual = isEqual && comps.hour == testComps.hour;
-    isEqual = isEqual && comps.minute == testComps.minute;
-    isEqual = isEqual && comps.second == testComps.second;
-    isEqual = isEqual && comps.nanosecond == testComps.nanosecond;
-    isEqual = isEqual && comps.weekday == testComps.weekday;
-    isEqual = isEqual && comps.weekdayOrdinal == testComps.weekdayOrdinal;
-    isEqual = isEqual && comps.quarter == testComps.quarter;
-    isEqual = isEqual && comps.weekOfMonth == testComps.weekOfMonth;
-    isEqual = isEqual && comps.weekOfYear == testComps.weekOfYear;
-    isEqual = isEqual && comps.yearForWeekOfYear == testComps.yearForWeekOfYear;
-    isEqual = isEqual && comps.leapMonth == testComps.leapMonth;
-
-    return isEqual;
 }
 
 @end
@@ -249,23 +198,23 @@ describe(@"NSLocale", ^{
 
 describe(@"NSDateComponents", ^{
     it(@"should encode and decode properly with NSCoder", ^{
-        NSDateComponents *origComps = [CMHTestCodingWrapper testDateComponents];
+        NSDateComponents *origComps = [CMHWrapperTestFactory testDateComponents];
         NSData *compsData = [NSKeyedArchiver archivedDataWithRootObject:origComps];
         NSDateComponents *codedComps = [NSKeyedUnarchiver unarchiveObjectWithData:compsData];
 
         expect(origComps == codedComps).to.beFalsy();
-        expect([CMHTestCodingWrapper isEquivalentToTest:codedComps]).to.beTruthy();
+        expect([CMHWrapperTestFactory isEquivalentToTestDateComponents:codedComps]).to.beTruthy();
     });
 
     it(@"should encode and decode properly with CMCoder", ^{
         CMHTestCodingWrapper *origWrapper = [CMHTestCodingWrapper new];
-        origWrapper.comps = [CMHTestCodingWrapper testDateComponents];
+        origWrapper.comps = [CMHWrapperTestFactory testDateComponents];
         NSDictionary *encodedObjects = [CMObjectEncoder encodeObjects:@[origWrapper]];
         CMHTestCodingWrapper *codedWrapper = [CMObjectDecoder decodeObjects:encodedObjects].firstObject;
 
         expect(codedWrapper).notTo.beNil();
         expect(origWrapper == codedWrapper).to.beFalsy();
-        expect([CMHTestCodingWrapper isEquivalentToTest:codedWrapper.comps]).to.beTruthy();
+        expect([CMHWrapperTestFactory isEquivalentToTestDateComponents:codedWrapper.comps]).to.beTruthy();
     });
 });
 

--- a/Example/Tests/CMHIntegrationTests.m
+++ b/Example/Tests/CMHIntegrationTests.m
@@ -1,6 +1,7 @@
 #import <CMHealth/CMHealth.h>
 #import "CMHTest-Secrets.h"
 #import "CMHTestCleaner.h"
+#import "CMHWrapperTestFactory.h"
 
 static NSString *const TestDescriptor = @"CMHTestDescriptor";
 static NSString *const TestPassword   = @"test-paSsword1!";
@@ -188,7 +189,10 @@ describe(@"CMHealthIntegration", ^{
         dateResult.calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierChinese];
         dateResult.timeZone = [NSTimeZone timeZoneWithName:@"Pacific/Honolulu"];
 
-        taskResult.results = @[scaleResult, booleanResult, dateResult];
+        ORKTimeOfDayQuestionResult *timeResult = [ORKTimeOfDayQuestionResult new];
+        timeResult.dateComponentsAnswer = [CMHWrapperTestFactory testDateComponents];
+
+        taskResult.results = @[scaleResult, booleanResult, dateResult, timeResult];
 
         __block NSString *uploadStatus = nil;
         __block NSError *uploadError = nil;
@@ -234,6 +238,10 @@ describe(@"CMHealthIntegration", ^{
         expect(dateResult.dateAnswer.timeIntervalSince1970).to.equal(127.0);
         expect(dateResult.calendar).to.equal([NSCalendar calendarWithIdentifier:NSCalendarIdentifierChinese]);
         expect(dateResult.timeZone).to.equal([NSTimeZone timeZoneWithName:@"Pacific/Honolulu"]);
+
+        expect([task.results[3] class]).to.equal([ORKTimeOfDayQuestionResult class]);
+        ORKTimeOfDayQuestionResult *timeResult = (ORKTimeOfDayQuestionResult *)task.results[3];
+        expect([CMHWrapperTestFactory isEquivalentToTestDateComponents:timeResult.dateComponentsAnswer]).to.beTruthy();
     });
 
     it(@"should return emptry results for an unused descriptor", ^{

--- a/Example/Tests/CMHWrapperTestFactory.h
+++ b/Example/Tests/CMHWrapperTestFactory.h
@@ -3,4 +3,6 @@
 @interface CMHWrapperTestFactory : NSObject
 + (ORKTaskResult *)taskResult;
 + (BOOL)isEquivalent:(ORKTaskResult *)taskResult;
++ (NSDateComponents *)testDateComponents;
++ (BOOL)isEquivalentToTestDateComponents:(NSDateComponents *)comps;
 @end

--- a/Example/Tests/CMHWrapperTestFactory.m
+++ b/Example/Tests/CMHWrapperTestFactory.m
@@ -2,6 +2,8 @@
 
 @implementation CMHWrapperTestFactory
 
+#pragma mark ORKTaskResult
+
 + (ORKTaskResult *)taskResult
 {
     ORKTextQuestionResult *textQuestionResult = [ORKTextQuestionResult new];
@@ -28,5 +30,58 @@
     [((ORKStepResult *)taskResult.firstResult).results[1] isKindOfClass:[ORKScaleQuestionResult class]] &&
     ((ORKScaleQuestionResult *)((ORKStepResult *)taskResult.firstResult).results[1]).scaleAnswer.floatValue == 1.16f;
 }
+
+#pragma mark NSDateComponents
+
++ (NSDateComponents *)testDateComponents
+{
+    NSDateComponents *comps = [NSDateComponents new];
+    comps.calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierHebrew];
+    comps.timeZone = [NSTimeZone timeZoneWithName:@"Pacific/Honolulu"];
+    comps.era = 1;
+    comps.year = 5000;
+    comps.month = 10;
+    comps.day = 12;
+    comps.hour = 7;
+    comps.minute = 16;
+    comps.second = 6;
+    comps.nanosecond = 4;
+    comps.weekday = 3;
+    comps.weekdayOrdinal = 2;
+    comps.quarter = 2;
+    comps.weekOfMonth = 1;
+    comps.weekOfYear = 40;
+    comps.yearForWeekOfYear = 8;
+    comps.leapMonth = NO;
+
+    return comps;
+}
+
++ (BOOL)isEquivalentToTestDateComponents:(NSDateComponents *)comps
+{
+    NSDateComponents *testComps = [self testDateComponents];
+
+    BOOL isEqual = YES;
+    isEqual = isEqual && [comps.calendar.calendarIdentifier isEqualToString:testComps.calendar.calendarIdentifier];
+    isEqual = isEqual && [comps.timeZone.name isEqualToString:testComps.timeZone.name];
+    isEqual = isEqual && comps.era == testComps.era;
+    isEqual = isEqual && comps.year == testComps.year;
+    isEqual = isEqual && comps.month == testComps.month;
+    isEqual = isEqual && comps.day == testComps.day;
+    isEqual = isEqual && comps.hour == testComps.hour;
+    isEqual = isEqual && comps.minute == testComps.minute;
+    isEqual = isEqual && comps.second == testComps.second;
+    isEqual = isEqual && comps.nanosecond == testComps.nanosecond;
+    isEqual = isEqual && comps.weekday == testComps.weekday;
+    isEqual = isEqual && comps.weekdayOrdinal == testComps.weekdayOrdinal;
+    isEqual = isEqual && comps.quarter == testComps.quarter;
+    isEqual = isEqual && comps.weekOfMonth == testComps.weekOfMonth;
+    isEqual = isEqual && comps.weekOfYear == testComps.weekOfYear;
+    isEqual = isEqual && comps.yearForWeekOfYear == testComps.yearForWeekOfYear;
+    isEqual = isEqual && comps.leapMonth == testComps.leapMonth;
+
+    return isEqual;
+}
+
 
 @end

--- a/Pod/Classes/Cocoa+CMHealth.h
+++ b/Pod/Classes/Cocoa+CMHealth.h
@@ -15,3 +15,6 @@
 
 @interface NSLocale (CMHealth)<CMCoding>
 @end
+
+@interface NSDateComponents (CMHealth)<CMCoding>
+@end

--- a/Pod/Classes/Cocoa+CMHealth.m
+++ b/Pod/Classes/Cocoa+CMHealth.m
@@ -146,5 +146,7 @@ void cmh_swizzle(Class class, SEL originalSelector, SEL swizzledSelector)
 
 @end
 
+@implementation NSDateComponents (CMHealth)
+@end
 @implementation NSLocale (CMHealth)
 @end

--- a/Pod/Classes/Cocoa+CMHealth.m
+++ b/Pod/Classes/Cocoa+CMHealth.m
@@ -146,7 +146,8 @@ void cmh_swizzle(Class class, SEL originalSelector, SEL swizzledSelector)
 
 @end
 
-@implementation NSDateComponents (CMHealth)
-@end
 @implementation NSLocale (CMHealth)
+@end
+
+@implementation NSDateComponents (CMHealth)
 @end


### PR DESCRIPTION
Unit, regression, and integration tests for serialization of the `ORKTimeOfDayQuestionResult`. Specifically, we had to "implement" `CMCoding` for the non primitive `NSDateComponents` type, of which the result object has a property.

**This pull request should be merged after #73**