### PR TITLE
Update for Compatibility with CocoaPods 1.0.0

### DIFF
--- a/CMHealth.podspec
+++ b/CMHealth.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
     'CMHealth' => ['Pod/Assets/*']
   }
 
-  s.dependency 'ResearchKit', '~> 1.3'
+  s.dependency 'ResearchKit', '~> 1.3.1'
   s.dependency 'CloudMine', '~> 1.7'
   s.dependency 'TPKeyboardAvoiding', '~> 1.2'
 end

--- a/Example/CMHealth.xcodeproj/project.pbxproj
+++ b/Example/CMHealth.xcodeproj/project.pbxproj
@@ -19,9 +19,8 @@
 		6003F5B2195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
 		6003F5BA195388D20070C39A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6003F5B8195388D20070C39A /* InfoPlist.strings */; };
 		6003F5BC195388D20070C39A /* CMHIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6003F5BB195388D20070C39A /* CMHIntegrationTests.m */; };
+		6C392F78590A34F3ADA0299B /* Pods_CMHealth_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BA608B4FEDC37041B69ACBD6 /* Pods_CMHealth_Example.framework */; };
 		873B8AEB1B1F5CCA007FD442 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 873B8AEA1B1F5CCA007FD442 /* Main.storyboard */; };
-		97C0DAB66397A93784E32D33 /* Pods_CMHealth_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 431D85A5C170F2A74B023DD6 /* Pods_CMHealth_Tests.framework */; };
-		AADE274BB5620631181D3B4A /* Pods_CMHealth_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F0A86E2796A10F23CD8FFB5E /* Pods_CMHealth_Example.framework */; };
 		B447ED501C8E215500DC6208 /* Test-Signature-Image.png in Resources */ = {isa = PBXBuildFile; fileRef = B447ED4F1C8E215500DC6208 /* Test-Signature-Image.png */; };
 		B447ED591C8F772800DC6208 /* CMHConsentValidatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B447ED581C8F772800DC6208 /* CMHConsentValidatorTests.m */; };
 		B447ED5B1C91EB3D00DC6208 /* CMHInputValidatorsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B447ED5A1C91EB3D00DC6208 /* CMHInputValidatorsTests.m */; };
@@ -33,6 +32,7 @@
 		B447ED681C98755500DC6208 /* Test-Consent-PDF.pdf in Resources */ = {isa = PBXBuildFile; fileRef = B447ED671C98755500DC6208 /* Test-Consent-PDF.pdf */; };
 		B447ED6B1C98A01D00DC6208 /* CMHTestCleaner.m in Sources */ = {isa = PBXBuildFile; fileRef = B447ED6A1C98A01D00DC6208 /* CMHTestCleaner.m */; };
 		B4508D371CA452A300A95BC2 /* CMHBundleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B4508D361CA452A300A95BC2 /* CMHBundleTests.m */; };
+		CCB9C20EB82A466AF455F60A /* Pods_CMHealth_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2ACFFEE579378187005AF449 /* Pods_CMHealth_Tests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -46,10 +46,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1FDDB7260794F2A80B444C12 /* Pods-CMHealth_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CMHealth_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-CMHealth_Tests/Pods-CMHealth_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		23175DD71A0716F8960DE2C5 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
-		2C7A9EE1CC8E5EB244D173F4 /* Pods-CMHealth_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CMHealth_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-CMHealth_Example/Pods-CMHealth_Example.release.xcconfig"; sourceTree = "<group>"; };
-		431D85A5C170F2A74B023DD6 /* Pods_CMHealth_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CMHealth_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2ACFFEE579378187005AF449 /* Pods_CMHealth_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CMHealth_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4DB332A4478E858CCD2BF2C8 /* CMHealth.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = CMHealth.podspec; path = ../CMHealth.podspec; sourceTree = "<group>"; };
+		55638E395C48F47A77F707CC /* Pods-CMHealth_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CMHealth_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-CMHealth_Tests/Pods-CMHealth_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		6003F58A195388D20070C39A /* CMHealth_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CMHealth_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58D195388D20070C39A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		6003F58F195388D20070C39A /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -68,10 +69,10 @@
 		6003F5B9195388D20070C39A /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		6003F5BB195388D20070C39A /* CMHIntegrationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMHIntegrationTests.m; sourceTree = "<group>"; };
 		606FC2411953D9B200FFA9A0 /* Tests-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Tests-Prefix.pch"; sourceTree = "<group>"; };
-		812C4B8738B6F9701D594161 /* Pods-CMHealth_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CMHealth_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-CMHealth_Example/Pods-CMHealth_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		873B8AEA1B1F5CCA007FD442 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
-		974DEEB5A4116D10FF749933 /* Pods-CMHealth_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CMHealth_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-CMHealth_Tests/Pods-CMHealth_Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		875D4682DE34D4BD73920712 /* Pods-CMHealth_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CMHealth_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-CMHealth_Example/Pods-CMHealth_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		9B8848021EAD16D813BECEAA /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
+		9FA9A5D4D3F1EEF37D195428 /* Pods-CMHealth_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CMHealth_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-CMHealth_Example/Pods-CMHealth_Example.release.xcconfig"; sourceTree = "<group>"; };
 		B447ED4E1C8DED1500DC6208 /* CMHTest-Secrets.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CMHTest-Secrets.h"; sourceTree = "<group>"; };
 		B447ED4F1C8E215500DC6208 /* Test-Signature-Image.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Test-Signature-Image.png"; sourceTree = "<group>"; };
 		B447ED581C8F772800DC6208 /* CMHConsentValidatorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMHConsentValidatorTests.m; sourceTree = "<group>"; };
@@ -86,8 +87,7 @@
 		B447ED691C98A01D00DC6208 /* CMHTestCleaner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CMHTestCleaner.h; sourceTree = "<group>"; };
 		B447ED6A1C98A01D00DC6208 /* CMHTestCleaner.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMHTestCleaner.m; sourceTree = "<group>"; };
 		B4508D361CA452A300A95BC2 /* CMHBundleTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMHBundleTests.m; sourceTree = "<group>"; };
-		F0A86E2796A10F23CD8FFB5E /* Pods_CMHealth_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CMHealth_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FEB06221139C06DAA962E0A6 /* Pods-CMHealth_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CMHealth_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-CMHealth_Tests/Pods-CMHealth_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		BA608B4FEDC37041B69ACBD6 /* Pods_CMHealth_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CMHealth_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -98,7 +98,7 @@
 				6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */,
 				6003F592195388D20070C39A /* UIKit.framework in Frameworks */,
 				6003F58E195388D20070C39A /* Foundation.framework in Frameworks */,
-				AADE274BB5620631181D3B4A /* Pods_CMHealth_Example.framework in Frameworks */,
+				6C392F78590A34F3ADA0299B /* Pods_CMHealth_Example.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -109,13 +109,24 @@
 				6003F5B0195388D20070C39A /* XCTest.framework in Frameworks */,
 				6003F5B2195388D20070C39A /* UIKit.framework in Frameworks */,
 				6003F5B1195388D20070C39A /* Foundation.framework in Frameworks */,
-				97C0DAB66397A93784E32D33 /* Pods_CMHealth_Tests.framework in Frameworks */,
+				CCB9C20EB82A466AF455F60A /* Pods_CMHealth_Tests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		26566F3B43747D55B1741C10 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				875D4682DE34D4BD73920712 /* Pods-CMHealth_Example.debug.xcconfig */,
+				9FA9A5D4D3F1EEF37D195428 /* Pods-CMHealth_Example.release.xcconfig */,
+				1FDDB7260794F2A80B444C12 /* Pods-CMHealth_Tests.debug.xcconfig */,
+				55638E395C48F47A77F707CC /* Pods-CMHealth_Tests.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
 		6003F581195388D10070C39A = {
 			isa = PBXGroup;
 			children = (
@@ -124,7 +135,7 @@
 				6003F5B5195388D20070C39A /* Tests */,
 				6003F58C195388D20070C39A /* Frameworks */,
 				6003F58B195388D20070C39A /* Products */,
-				ED91E6E2C6596827EBA65304 /* Pods */,
+				26566F3B43747D55B1741C10 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -144,8 +155,8 @@
 				6003F58F195388D20070C39A /* CoreGraphics.framework */,
 				6003F591195388D20070C39A /* UIKit.framework */,
 				6003F5AF195388D20070C39A /* XCTest.framework */,
-				F0A86E2796A10F23CD8FFB5E /* Pods_CMHealth_Example.framework */,
-				431D85A5C170F2A74B023DD6 /* Pods_CMHealth_Tests.framework */,
+				BA608B4FEDC37041B69ACBD6 /* Pods_CMHealth_Example.framework */,
+				2ACFFEE579378187005AF449 /* Pods_CMHealth_Tests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -218,17 +229,6 @@
 			name = "Podspec Metadata";
 			sourceTree = "<group>";
 		};
-		ED91E6E2C6596827EBA65304 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				812C4B8738B6F9701D594161 /* Pods-CMHealth_Example.debug.xcconfig */,
-				2C7A9EE1CC8E5EB244D173F4 /* Pods-CMHealth_Example.release.xcconfig */,
-				974DEEB5A4116D10FF749933 /* Pods-CMHealth_Tests.debug.xcconfig */,
-				FEB06221139C06DAA962E0A6 /* Pods-CMHealth_Tests.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -236,12 +236,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6003F5BF195388D20070C39A /* Build configuration list for PBXNativeTarget "CMHealth_Example" */;
 			buildPhases = (
-				F361B9EB3956C2238FDC255F /* Check Pods Manifest.lock */,
+				16129520D8CCEAFB0B4B6C62 /* 📦 Check Pods Manifest.lock */,
 				6003F586195388D20070C39A /* Sources */,
 				6003F587195388D20070C39A /* Frameworks */,
 				6003F588195388D20070C39A /* Resources */,
-				39DCA4E3C361EB6AD7F052E6 /* Embed Pods Frameworks */,
-				8016E4915B8083F5DEF58C56 /* Copy Pods Resources */,
+				A0C6AD43957902483C80FDB8 /* 📦 Embed Pods Frameworks */,
+				2F2C04CC369F6EE0D5723A38 /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -256,12 +256,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6003F5C2195388D20070C39A /* Build configuration list for PBXNativeTarget "CMHealth_Tests" */;
 			buildPhases = (
-				CC05472CF7596BFC45A0DA9C /* Check Pods Manifest.lock */,
+				A88ADF52CC8CEE0DADA2684C /* 📦 Check Pods Manifest.lock */,
 				6003F5AA195388D20070C39A /* Sources */,
 				6003F5AB195388D20070C39A /* Frameworks */,
 				6003F5AC195388D20070C39A /* Resources */,
-				E148DBC0E3F1B3E363A196E4 /* Embed Pods Frameworks */,
-				3B3AE15726FF7B42B8FD2E48 /* Copy Pods Resources */,
+				0D861D392312712FE2412028 /* 📦 Embed Pods Frameworks */,
+				5426AD50D48DD05DD5293C49 /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -330,74 +330,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		39DCA4E3C361EB6AD7F052E6 /* Embed Pods Frameworks */ = {
+		0D861D392312712FE2412028 /* 📦 Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CMHealth_Example/Pods-CMHealth_Example-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		3B3AE15726FF7B42B8FD2E48 /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CMHealth_Tests/Pods-CMHealth_Tests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		8016E4915B8083F5DEF58C56 /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CMHealth_Example/Pods-CMHealth_Example-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		CC05472CF7596BFC45A0DA9C /* Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		E148DBC0E3F1B3E363A196E4 /* Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Embed Pods Frameworks";
+			name = "📦 Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -405,14 +345,74 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CMHealth_Tests/Pods-CMHealth_Tests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		F361B9EB3956C2238FDC255F /* Check Pods Manifest.lock */ = {
+		16129520D8CCEAFB0B4B6C62 /* 📦 Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "📦 Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		2F2C04CC369F6EE0D5723A38 /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CMHealth_Example/Pods-CMHealth_Example-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		5426AD50D48DD05DD5293C49 /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CMHealth_Tests/Pods-CMHealth_Tests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		A0C6AD43957902483C80FDB8 /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CMHealth_Example/Pods-CMHealth_Example-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		A88ADF52CC8CEE0DADA2684C /* 📦 Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -555,7 +555,7 @@
 		};
 		6003F5C0195388D20070C39A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 812C4B8738B6F9701D594161 /* Pods-CMHealth_Example.debug.xcconfig */;
+			baseConfigurationReference = 875D4682DE34D4BD73920712 /* Pods-CMHealth_Example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -574,7 +574,7 @@
 		};
 		6003F5C1195388D20070C39A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2C7A9EE1CC8E5EB244D173F4 /* Pods-CMHealth_Example.release.xcconfig */;
+			baseConfigurationReference = 9FA9A5D4D3F1EEF37D195428 /* Pods-CMHealth_Example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -593,7 +593,7 @@
 		};
 		6003F5C3195388D20070C39A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 974DEEB5A4116D10FF749933 /* Pods-CMHealth_Tests.debug.xcconfig */;
+			baseConfigurationReference = 1FDDB7260794F2A80B444C12 /* Pods-CMHealth_Tests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
@@ -618,7 +618,7 @@
 		};
 		6003F5C4195388D20070C39A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FEB06221139C06DAA962E0A6 /* Pods-CMHealth_Tests.release.xcconfig */;
+			baseConfigurationReference = 55638E395C48F47A77F707CC /* Pods-CMHealth_Tests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,13 +1,13 @@
 source 'https://github.com/CocoaPods/Specs.git'
 use_frameworks!
 
-target 'CMHealth_Example', :exclusive => true do
-  pod 'CMHealth', :path => '../'
-end
-
-target 'CMHealth_Tests', :exclusive => true do
+target 'CMHealth_Example' do
   pod 'CMHealth', :path => '../'
 
-  pod 'Specta'
-  pod 'Expecta'
+  target 'CMHealth_Tests' do
+    inherit! :search_paths
+
+    pod 'Specta'
+    pod 'Expecta'
+  end
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -25,12 +25,12 @@ PODS:
     - CloudMine/no-arc (= 1.7.11)
   - CloudMine/no-arc (1.7.11):
     - AFNetworking (~> 2.6.3)
-  - CMHealth (0.2.2):
+  - CMHealth (0.3.0):
     - CloudMine (~> 1.7)
-    - ResearchKit (~> 1.3)
+    - ResearchKit (~> 1.3.1)
     - TPKeyboardAvoiding (~> 1.2)
   - Expecta (1.0.5)
-  - ResearchKit (1.3.0)
+  - ResearchKit (1.3.1)
   - Specta (1.0.5)
   - TPKeyboardAvoiding (1.3)
 
@@ -46,10 +46,12 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
   CloudMine: ee5b3643fb1a2f4603de6428aea1252ac928d98d
-  CMHealth: 0ec5c10193f85644400408260e872f831d1644ab
+  CMHealth: 7a40693d7bea5f9f1c45734484917a415b226e51
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
-  ResearchKit: 934a1efefed1a3a9150002a1e4b123d0c86c3f2e
+  ResearchKit: badba0340dd71d1cbab4789a0bf01b26022b8f94
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
   TPKeyboardAvoiding: a5138f318c06fb3e151f886e18ce4a72695d9cbe
 
-COCOAPODS: 0.39.0
+PODFILE CHECKSUM: 945b636da21181a707901a018dfe56f60c53b7d1
+
+COCOAPODS: 1.0.0


### PR DESCRIPTION
Apple pushed a patch for ResearchKit (version 1.3.1) which included
our fix for CocoaPods 1.0.0 linking errors. Our Podspec must be updated
to reflect this requirement, as well as the dependencies in the Example/Test
Target app.