### PR TITLE
Fix warnings surfaced by pod lint

### DIFF
--- a/CMHealth.podspec
+++ b/CMHealth.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.platform          = :ios, '9.0'
   s.requires_arc      = true
 
-  s.public_header_files = 'CMHealth/CMHealth.h'
+  # s.public_header_files = 'Pod/Classes/CMHealth.h' # Pre 1.0 we need to specify exactly which should be public
   s.source_files         = 'Pod/Classes/**/*'
 
   s.resource_bundles  = {

--- a/Pod/Classes/CMHErrorUtilities.m
+++ b/Pod/Classes/CMHErrorUtilities.m
@@ -170,7 +170,7 @@
     }
 
     if (![error.domain isEqualToString:CMErrorDomain]) {
-        NSString *unknownMessage = [NSString stringWithFormat:@"%@. %@ (%@, %li)", prefix, error.localizedDescription, error.domain, error.code];
+        NSString *unknownMessage = [NSString stringWithFormat:@"%@. %@ (%@, %li)", prefix, error.localizedDescription, error.domain, (long)error.code];
         return [self errorWithCode:CMHErrorUnknown localizedDescription:unknownMessage];
     }
 

--- a/Pod/Classes/CMHMutedEventUpdater.m
+++ b/Pod/Classes/CMHMutedEventUpdater.m
@@ -1,7 +1,7 @@
 #import "CMHMutedEventUpdater.h"
 #import "OCKCarePlanEvent+CMHealth.h"
 
-@interface CMHMutedEventUpdater ()
+@interface CMHMutedEventUpdater ()<OCKCarePlanStoreDelegate>
 
 @property (nonatomic, nonnull) OCKCarePlanStore *store;
 @property (nonatomic, nonnull) OCKCarePlanEvent *event;


### PR DESCRIPTION
@JohnMcCarthy This resolved some warnings related to `pod spec lint`. I'm still unable to reproduce the exact error your received. Let's see what happens on your end after we merge this request.