### PR TITLE
Minor Updates for Development in Xcode 8

### DIFF
--- a/Example/CMHealth.xcodeproj/project.pbxproj
+++ b/Example/CMHealth.xcodeproj/project.pbxproj
@@ -602,7 +602,6 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 				);
@@ -627,7 +626,6 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 				);

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -20,11 +20,11 @@ PODS:
   - AFNetworking/UIKit (2.6.3):
     - AFNetworking/NSURLConnection
     - AFNetworking/NSURLSession
-  - CareKit (1.0.1)
-  - CloudMine (1.7.11):
+  - CareKit (1.0.2)
+  - CloudMine (1.7.12):
     - AFNetworking (~> 2.6.3)
-    - CloudMine/no-arc (= 1.7.11)
-  - CloudMine/no-arc (1.7.11):
+    - CloudMine/no-arc (= 1.7.12)
+  - CloudMine/no-arc (1.7.12):
     - AFNetworking (~> 2.6.3)
   - CMHealth (0.5.0):
     - CareKit (~> 1.0.1)
@@ -41,12 +41,12 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   CMHealth:
-    :path: "../"
+    :path: ../
 
 SPEC CHECKSUMS:
   AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
-  CareKit: 08e840f45807c7771708b731649e082bdb6eea2d
-  CloudMine: ee5b3643fb1a2f4603de6428aea1252ac928d98d
+  CareKit: 377857f33d3795ed6d24a5df116154773265f81a
+  CloudMine: 44e949fef2c3943cad2c375fa4d8c7cc87113275
   CMHealth: 966abb6a8d9689642e11c5f29a87ef2a761775c8
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   ResearchKit: badba0340dd71d1cbab4789a0bf01b26022b8f94


### PR DESCRIPTION
No changes to framework code: only impacts developing and testing the SDK itself in Xcode 8
- Update Dependencies
- Suppress silly path warning
