### PR TITLE
Implement Access to Patient Profile Data from Provider Side

### DIFF
--- a/CMHealth.podspec
+++ b/CMHealth.podspec
@@ -25,5 +25,5 @@ Pod::Spec.new do |s|
 
   s.dependency 'ResearchKit', '~> 1.3'
   s.dependency 'CareKit', '~> 1.2'
-  s.dependency 'CloudMine', '~> 1.7'
+  s.dependency 'CloudMine', '~> 1.7.16'
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -28,7 +28,7 @@ PODS:
     - AFNetworking (~> 2.6.3)
   - CMHealth (0.6.0):
     - CareKit (~> 1.2)
-    - CloudMine (~> 1.7)
+    - CloudMine (~> 1.7.16)
     - ResearchKit (~> 1.3)
   - Expecta (1.0.6)
   - ResearchKit (1.5.2)
@@ -47,7 +47,7 @@ SPEC CHECKSUMS:
   AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
   CareKit: aa0c8a57c1a2d7cfb46ff3981fe1503f02ca302e
   CloudMine: aa3a609ab22eec132ff446839da0f97072d6b4ec
-  CMHealth: c7a513beb7af2befab8e0cc1be2accad1fabcdd8
+  CMHealth: 32b5fc2959fbfcd69c33cac5f8d3a43967d60b34
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   ResearchKit: a5770681dd61afddd3d1f24d232b9abf00cba454
   Specta: f506f3a8361de16bc0dcf3b17b75e269072ba465

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -21,17 +21,17 @@ PODS:
     - AFNetworking/NSURLConnection
     - AFNetworking/NSURLSession
   - CareKit (1.2.1)
-  - CloudMine (1.7.15):
+  - CloudMine (1.7.16):
     - AFNetworking (~> 2.6.3)
-    - CloudMine/no-arc (= 1.7.15)
-  - CloudMine/no-arc (1.7.15):
+    - CloudMine/no-arc (= 1.7.16)
+  - CloudMine/no-arc (1.7.16):
     - AFNetworking (~> 2.6.3)
   - CMHealth (0.6.0):
     - CareKit (~> 1.2)
     - CloudMine (~> 1.7)
     - ResearchKit (~> 1.3)
-  - Expecta (1.0.5)
-  - ResearchKit (1.4.1)
+  - Expecta (1.0.6)
+  - ResearchKit (1.5.2)
   - Specta (1.0.6)
 
 DEPENDENCIES:
@@ -46,12 +46,12 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
   CareKit: aa0c8a57c1a2d7cfb46ff3981fe1503f02ca302e
-  CloudMine: a465ed5e1d37385bd076aad15407afef3c686041
+  CloudMine: aa3a609ab22eec132ff446839da0f97072d6b4ec
   CMHealth: c7a513beb7af2befab8e0cc1be2accad1fabcdd8
-  Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
-  ResearchKit: 3533ea3a2270e4ed7ff830e19755dc959fdfd430
+  Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
+  ResearchKit: a5770681dd61afddd3d1f24d232b9abf00cba454
   Specta: f506f3a8361de16bc0dcf3b17b75e269072ba465
 
-PODFILE CHECKSUM: e0bfe980733a4ec4564367b8513faf76065ffb83
+PODFILE CHECKSUM: 7a959d19a541dd8a94ff855ffb4efa25b2c85021
 
 COCOAPODS: 1.2.1

--- a/Example/Tests/CMHCareIntegrationTests.m
+++ b/Example/Tests/CMHCareIntegrationTests.m
@@ -579,7 +579,7 @@ describe(@"CMHCareIntegration", ^{
         __block NSError *fetchError = nil;
         
         waitUntil(^(DoneCallback done) {
-            [testPatient fetchProfileImageWithCompletion:^(BOOL success, UIImage *image, NSError *error) {
+            [testPatient cmh_fetchProfileImageWithCompletion:^(BOOL success, UIImage *image, NSError *error) {
                 photoFetchSuccess = success;
                 profileImage = image;
                 fetchError = error;

--- a/Example/Tests/CMHCareIntegrationTests.m
+++ b/Example/Tests/CMHCareIntegrationTests.m
@@ -88,6 +88,31 @@ describe(@"CMHCareIntegration", ^{
         expect([CMHUser currentUser].userData.isAdmin).to.beFalsy();
     });
     
+    it(@"should let us update the user's profile data", ^{
+        __block CMHUserData *updateUserData = nil;
+        __block NSError *updateError = nil;
+        
+        CMHMutableUserData *mutableUserData = [[CMHUser currentUser].userData mutableCopy];
+        mutableUserData.gender = CMHCareTestFactory.genderString;
+        mutableUserData.dateOfBirth = CMHCareTestFactory.dateOfBirth;
+        mutableUserData.userInfo = CMHCareTestFactory.userDataUserInfo;
+        
+        waitUntil(^(DoneCallback done) {
+            [[CMHUser currentUser] updateUserData:mutableUserData withCompletion:^(CMHUserData * _Nullable userData, NSError * _Nullable error) {
+                updateUserData = userData;
+                updateError = error;
+                done();
+            }];
+        });
+        
+        expect(updateError).to.beNil();
+        expect(updateUserData == [CMHUser currentUser].userData).to.beTruthy();
+        expect(updateUserData.isAdmin).to.equal(NO);
+        expect(updateUserData.gender).to.equal(CMHCareTestFactory.genderString);
+        expect(updateUserData.dateOfBirth).to.equal(CMHCareTestFactory.dateOfBirth);
+        expect(updateUserData.userInfo).to.equal(CMHCareTestFactory.userDataUserInfo);
+    });
+    
     it(@"should upload a user's profile photo", ^{
         UIImage *image = [UIImage imageNamed:@"Test-Signature-Image.png"];
         
@@ -571,6 +596,14 @@ describe(@"CMHCareIntegration", ^{
         }
         
         expect(adminPatient).to.beNil();
+        
+        // Ensure the patients user data is available and matches that set up
+        
+        expect(testPatient.cmh_patientUserData).notTo.beNil();
+        expect(testPatient.cmh_patientUserData.isAdmin).to.equal(NO);
+        expect(testPatient.cmh_patientUserData.gender).to.equal(CMHCareTestFactory.genderString);
+        expect(testPatient.cmh_patientUserData.dateOfBirth).to.equal(CMHCareTestFactory.dateOfBirth);
+        expect(testPatient.cmh_patientUserData.userInfo).to.equal(CMHCareTestFactory.userDataUserInfo);
         
         // Ensure the admin can fetch the patient's profile image
         

--- a/Example/Tests/CMHCareIntegrationTests.m
+++ b/Example/Tests/CMHCareIntegrationTests.m
@@ -9,6 +9,7 @@
 #import <CMHealth/CMHInternalUser.h>
 #import <CMHealth/CMHCareObjectSaver.h>
 #import <CMHealth/CMHCarePlanStoreVendor.h>
+#import <CMHealth/CareKit+CMHealth.h>
 
 @interface CMHCareIntegrationTestUtils : NSObject
 + (NSURL *)persistenceDirectory;
@@ -570,6 +571,27 @@ describe(@"CMHCareIntegration", ^{
         }
         
         expect(adminPatient).to.beNil();
+        
+        // Ensure the admin can fetch the patient's profile image
+        
+        __block BOOL photoFetchSuccess = NO;
+        __block UIImage *profileImage = nil;
+        __block NSError *fetchError = nil;
+        
+        waitUntil(^(DoneCallback done) {
+            [testPatient fetchProfileImageWithCompletion:^(BOOL success, UIImage *image, NSError *error) {
+                photoFetchSuccess = success;
+                profileImage = image;
+                fetchError = error;
+                done();
+            }];
+        });
+        
+        expect(photoFetchSuccess).to.beTruthy();
+        expect(fetchError).to.beNil();
+        expect(profileImage).notTo.beNil();
+        expect(profileImage.size.width).to.equal(1.0f);
+        expect(profileImage.size.height).to.equal(1.0f);
         
         // Ensure the assessement activity matches that added as a patient
         

--- a/Example/Tests/CMHCareTestFactory.h
+++ b/Example/Tests/CMHCareTestFactory.h
@@ -8,4 +8,8 @@
 + (NSDateComponents *)weekInTheFutureComponents;
 + (OCKCarePlanEventResult *)assessmentEventResult;
 
++ (NSString *)genderString;
++ (NSDate *)dateOfBirth;
++ (NSDictionary *)userDataUserInfo;
+
 @end

--- a/Example/Tests/CMHCareTestFactory.m
+++ b/Example/Tests/CMHCareTestFactory.m
@@ -7,6 +7,24 @@ static NSString *const CMHIdentifierAssessmentPainTrack          = @"CMHPainTrac
 
 @implementation CMHCareTestFactory
 
++ (NSString *)genderString
+{
+    return @"female";
+}
+
++ (NSDate *)dateOfBirth
+{
+    return [NSDate dateWithTimeIntervalSince1970:116000];
+}
+
++ (NSDictionary *)userDataUserInfo
+{
+    return @{ @"key1" : @"A String element",
+              @"key2" : @YES,
+              @"key3" : @116,
+              @"key4" : @[@"Hello", @"World"] };
+}
+
 + (OCKCarePlanActivity *)interventionActivity
 {
     OCKCareSchedule *schedule = [OCKCareSchedule dailyScheduleWithStartDate:[self weekAgoComponents] occurrencesPerDay:3];

--- a/Example/Tests/CMHTest-Secrets.h-Template
+++ b/Example/Tests/CMHTest-Secrets.h-Template
@@ -4,6 +4,9 @@
 static NSString *const CMHTestsAppId  = @"REPLACE_WITH_AN_APP_ID_TO_USE_FOR_TESTING";
 static NSString *const CMHTestsAPIKey = @"REPLACE_WITH_API_KEY";
 static NSString *const CMHTestsSharedSnippetName = @"REPLACE_WITH_A_SNIPPET_FOR_SHARING_SAVED_CAREKIT_DATA_TO_USE_FOR_TESTING";
+static NSString *const CMHTestsCareAdminEmail = @"REPLACE_WITH_AN_ADMIN_USER_EMAIL_THAT_HAS_PROPER_ACL_ACCESS"
+static NSString *const CMHTestsCareAdminPassword = @"REPLACE_WITH_PASSWORD_FOR_ADMIN_USER_LOGIN"
+
 static const NSTimeInterval CMHTestsAsyncTimeout = 10.0;
 
 #endif

--- a/Pod/Classes/CMHCareFileMetadata.h
+++ b/Pod/Classes/CMHCareFileMetadata.h
@@ -1,0 +1,7 @@
+#import <CloudMine/CMFileMetadata.h>
+
+@interface CMHCareFileMetadata : CMFileMetadata
+
+@property (nonatomic, copy, nullable) NSString *cmhOwnerId;
+
+@end

--- a/Pod/Classes/CMHCareFileMetadata.m
+++ b/Pod/Classes/CMHCareFileMetadata.m
@@ -1,0 +1,22 @@
+#import "CMHCareFileMetadata.h"
+#import "CMHConstants_internal.h"
+
+@implementation CMHCareFileMetadata
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
+{
+    self = [super initWithCoder:aDecoder];
+    if (nil == self) { return nil; }
+    
+    _cmhOwnerId = [aDecoder decodeObjectForKey:CMHOwningUserKey];
+    
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder
+{
+    [super encodeWithCoder:aCoder];
+    [aCoder encodeObject:self.cmhOwnerId forKey:CMHOwningUserKey];
+}
+
+@end

--- a/Pod/Classes/CMHCarePlanStore.m
+++ b/Pod/Classes/CMHCarePlanStore.m
@@ -165,6 +165,12 @@
                 patientDetail = user.email;
             }
             
+            NSDictionary *patientInfo = nil;
+            
+            if (nil != profile.photoId) {
+                patientInfo = @{ @"photoId" : [profile.photoId copy] };
+            }
+            
             NSURL *patientDir = [CMHCarePlanStore persistenceDirectoryNamed:user.objectId];
             __block CMHCarePlanStore *patientStore = nil;
             
@@ -202,7 +208,7 @@
                                                                 monogram:nil
                                                                    image:nil
                                                               categories:nil
-                                                                userInfo:nil];
+                                                                userInfo:patientInfo];
             [mutablePatients addObject:patient];
         }
         

--- a/Pod/Classes/CMHCarePlanStore.m
+++ b/Pod/Classes/CMHCarePlanStore.m
@@ -13,6 +13,8 @@
 #import "CMHCarePlanStoreVendor.h"
 #import "CMHSyncStamper.h"
 #import "CMHAutoPager.h"
+#import "CMHUserData_internal.h"
+#import "OCKPatient+CMHealth.h"
 
 @interface CMHCarePlanStore ()<OCKCarePlanStoreDelegate>
 
@@ -145,8 +147,9 @@
             NSString *patientName = user.email;
             NSString *patientDetail = nil;
             CMHInternalProfile *profile = [CMHCarePlanStore profileForUser:(CMHInternalUser *)user from:allProfiles];
+            CMHUserData *userData = [[CMHUserData alloc] initWithInternalProfile:profile userId:user.objectId];
             
-            if (nil == profile || profile.isAdmin) {
+            if (nil == profile || profile.isAdmin || nil == userData) {
                 continue;
             }
 
@@ -168,7 +171,10 @@
             NSDictionary *patientInfo = nil;
             
             if (nil != profile.photoId) {
-                patientInfo = @{ @"photoId" : [profile.photoId copy] };
+                patientInfo =  @{ CMHPatientUserInfoUserDataKey: userData,
+                                  CMHPatientUserInfoPhotoIdKey: profile.photoId, };
+            } else {
+                patientInfo = @{ CMHPatientUserInfoUserDataKey: userData, };
             }
             
             NSURL *patientDir = [CMHCarePlanStore persistenceDirectoryNamed:user.objectId];

--- a/Pod/Classes/CMHCarePlanStore_internal.h
+++ b/Pod/Classes/CMHCarePlanStore_internal.h
@@ -1,4 +1,5 @@
 #import "CMHCarePlanStore.h"
+#import "CMHUser.h"
 
 @interface CMHCarePlanStore ()
 

--- a/Pod/Classes/CMHealth.h
+++ b/Pod/Classes/CMHealth.h
@@ -11,6 +11,7 @@
 #import "CMHLoginViewController.h"
 #import "CMHCarePlanStore.h"
 #import "CMHCareSyncBlocks.h"
+#import "OCKPatient+CMHealth.h"
 
 /**
  *  CMHealth is the easiest way to add secure, HIPAA compliant cloud data storage and user

--- a/Pod/Classes/CareKit+CMHealth.h
+++ b/Pod/Classes/CareKit+CMHealth.h
@@ -16,9 +16,3 @@
 
 @interface OCKCarePlanThreshold (CMHealth)<CMCoding>
 @end
-
-@interface OCKPatient (CMHealth)
-
-- (void)fetchProfileImageWithCompletion:(_Nullable CMHFetchProfileImageCompletion)block;
-
-@end

--- a/Pod/Classes/CareKit+CMHealth.h
+++ b/Pod/Classes/CareKit+CMHealth.h
@@ -1,5 +1,6 @@
 #import <CareKit/CareKit.h>
-#import <CloudMine/CloudMine.h>
+#import <CloudMine/CMCoding.h>
+#import <CMHealth/CMHUser.h>
 
 @interface OCKCarePlanActivity (CMHealth)<CMCoding>
 
@@ -14,4 +15,10 @@
 @end
 
 @interface OCKCarePlanThreshold (CMHealth)<CMCoding>
+@end
+
+@interface OCKPatient (CMHealth)
+
+- (void)fetchProfileImageWithCompletion:(_Nullable CMHFetchProfileImageCompletion)block;
+
 @end

--- a/Pod/Classes/CareKit+CMHealth.m
+++ b/Pod/Classes/CareKit+CMHealth.m
@@ -1,5 +1,8 @@
 #import "CareKit+CMHealth.h"
+#import <CloudMine/CloudMine.h>
 #import "CMHObjectUtilities.h"
+#import "CMHCarePlanStore.h"
+
 
 @implementation OCKCarePlanActivity (CMHealth)
 
@@ -26,4 +29,48 @@
 @end
 
 @implementation OCKCarePlanThreshold (CMHealth)
+@end
+
+@implementation OCKPatient (CMHealth)
+
+- (void)fetchProfileImageWithCompletion:(_Nullable CMHFetchProfileImageCompletion)block
+{
+    if (![self.store isKindOfClass:[CMHCarePlanStore class]] ||
+        nil == self.userInfo ||
+        nil == self.userInfo[@"photoId"])
+    {
+        if (nil != block) {
+            block(YES, nil, nil);
+        }
+        
+        return;
+    }
+    
+    NSString *photoId = (NSString *)self.userInfo[@"photoId"];
+    CMStoreOptions *shareOption = [CMStoreOptions new];
+    shareOption.shared = YES;
+    
+    [[CMStore defaultStore] userFileWithName:photoId additionalOptions:shareOption callback:^(CMFileFetchResponse *response) {
+        if (nil != response.error) {
+            if (nil != block) {
+                block(NO, nil, response.error);
+            }
+            return;
+        }
+        
+        if (nil == response.file.fileData) {
+            if (nil != block) {
+                block(YES, nil, nil);
+            }
+            return;
+        }
+        
+        UIImage *profileImage = [UIImage imageWithData:response.file.fileData];
+        
+        if (nil != block) {
+            block(YES, profileImage, nil);
+        }
+    }];
+}
+
 @end

--- a/Pod/Classes/CareKit+CMHealth.m
+++ b/Pod/Classes/CareKit+CMHealth.m
@@ -1,8 +1,5 @@
 #import "CareKit+CMHealth.h"
-#import <CloudMine/CloudMine.h>
 #import "CMHObjectUtilities.h"
-#import "CMHCarePlanStore.h"
-
 
 @implementation OCKCarePlanActivity (CMHealth)
 
@@ -29,48 +26,4 @@
 @end
 
 @implementation OCKCarePlanThreshold (CMHealth)
-@end
-
-@implementation OCKPatient (CMHealth)
-
-- (void)fetchProfileImageWithCompletion:(_Nullable CMHFetchProfileImageCompletion)block
-{
-    if (![self.store isKindOfClass:[CMHCarePlanStore class]] ||
-        nil == self.userInfo ||
-        nil == self.userInfo[@"photoId"])
-    {
-        if (nil != block) {
-            block(YES, nil, nil);
-        }
-        
-        return;
-    }
-    
-    NSString *photoId = (NSString *)self.userInfo[@"photoId"];
-    CMStoreOptions *shareOption = [CMStoreOptions new];
-    shareOption.shared = YES;
-    
-    [[CMStore defaultStore] userFileWithName:photoId additionalOptions:shareOption callback:^(CMFileFetchResponse *response) {
-        if (nil != response.error) {
-            if (nil != block) {
-                block(NO, nil, response.error);
-            }
-            return;
-        }
-        
-        if (nil == response.file.fileData) {
-            if (nil != block) {
-                block(YES, nil, nil);
-            }
-            return;
-        }
-        
-        UIImage *profileImage = [UIImage imageWithData:response.file.fileData];
-        
-        if (nil != block) {
-            block(YES, profileImage, nil);
-        }
-    }];
-}
-
 @end

--- a/Pod/Classes/OCKPatient+CMHealth.h
+++ b/Pod/Classes/OCKPatient+CMHealth.h
@@ -1,6 +1,9 @@
 #import <CareKit/CareKit.h>
 #import <CMHealth/CMHUser.h>
 
+extern NSString * const _Nonnull CMHPatientUserInfoUserDataKey;
+extern NSString * const _Nonnull CMHPatientUserInfoPhotoIdKey;
+
 @interface OCKPatient (CMHealth)
 
 - (void)cmh_fetchProfileImageWithCompletion:(_Nullable CMHFetchProfileImageCompletion)block;

--- a/Pod/Classes/OCKPatient+CMHealth.h
+++ b/Pod/Classes/OCKPatient+CMHealth.h
@@ -6,6 +6,7 @@ extern NSString * const _Nonnull CMHPatientUserInfoPhotoIdKey;
 
 @interface OCKPatient (CMHealth)
 
+@property (nonatomic, nullable, readonly) CMHUserData *cmh_patientUserData;
 - (void)cmh_fetchProfileImageWithCompletion:(_Nullable CMHFetchProfileImageCompletion)block;
 
 @end

--- a/Pod/Classes/OCKPatient+CMHealth.h
+++ b/Pod/Classes/OCKPatient+CMHealth.h
@@ -1,0 +1,8 @@
+#import <CareKit/CareKit.h>
+#import <CMHealth/CMHUser.h>
+
+@interface OCKPatient (CMHealth)
+
+- (void)cmh_fetchProfileImageWithCompletion:(_Nullable CMHFetchProfileImageCompletion)block;
+
+@end

--- a/Pod/Classes/OCKPatient+CMHealth.h
+++ b/Pod/Classes/OCKPatient+CMHealth.h
@@ -6,7 +6,21 @@ extern NSString * const _Nonnull CMHPatientUserInfoPhotoIdKey;
 
 @interface OCKPatient (CMHealth)
 
+/**
+ *  This property will be populated for patient objects fetched by 
+ *  a Care Provider from an instance of `CMHCarePlanStore`.
+ *  It exposes the same `CMHUserData` that is created and configurable
+ *  by the patient through their `CMHUser` instance.
+ */
 @property (nonatomic, nullable, readonly) CMHUserData *cmh_patientUserData;
+
+/**
+ *  Fetch the patient's profile image, if one exists, or nil if not.
+ *  This method is meant for use in conjunction with patient objects fetched by
+ *  an instance of `CMHCarePlanStore` in a Care Provider app context.
+ *
+ *  @param block Executes when image has been fetched successfully or fails with an error.
+ */
 - (void)cmh_fetchProfileImageWithCompletion:(_Nullable CMHFetchProfileImageCompletion)block;
 
 @end

--- a/Pod/Classes/OCKPatient+CMHealth.m
+++ b/Pod/Classes/OCKPatient+CMHealth.m
@@ -1,6 +1,7 @@
 #import "OCKPatient+CMHealth.h"
 #import <CloudMine/CloudMine.h>
 #import "CMHCarePlanStore.h"
+#import "CMHUserData.h"
 
 NSString * const _Nonnull CMHPatientUserInfoUserDataKey = @"com.cloudmineinc.com.CMHealth.PhotoId";
 NSString * const _Nonnull CMHPatientUserInfoPhotoIdKey = @"com.cloudmineinc.com.CMHealth.PatientData";
@@ -9,6 +10,19 @@ NSString * const _Nonnull CMHPatientUserInfoPhotoIdKey = @"com.cloudmineinc.com.
 
 // TODO: Accessorthe patient data
 // TODO SOMEDAY: Update patient data from provider side
+
+- (CMHUserData *)cmh_patientUserData
+{
+    if (![self.store isKindOfClass:[CMHCarePlanStore class]] ||
+        nil == self.userInfo ||
+        nil == self.userInfo[CMHPatientUserInfoUserDataKey] ||
+        ![(NSObject *)self.userInfo[CMHPatientUserInfoUserDataKey] isKindOfClass:[CMHUserData class]])
+    {
+        return nil;
+    }
+    
+    return (CMHUserData *)self.userInfo[CMHPatientUserInfoUserDataKey];
+}
 
 - (void)cmh_fetchProfileImageWithCompletion:(_Nullable CMHFetchProfileImageCompletion)block
 {

--- a/Pod/Classes/OCKPatient+CMHealth.m
+++ b/Pod/Classes/OCKPatient+CMHealth.m
@@ -8,8 +8,7 @@ NSString * const _Nonnull CMHPatientUserInfoPhotoIdKey = @"com.cloudmineinc.com.
 
 @implementation OCKPatient (CMHealth)
 
-// TODO: Accessorthe patient data
-// TODO SOMEDAY: Update patient data from provider side
+// TODO SOMEDAY: Allow updating the patient data from provider side
 
 - (CMHUserData *)cmh_patientUserData
 {

--- a/Pod/Classes/OCKPatient+CMHealth.m
+++ b/Pod/Classes/OCKPatient+CMHealth.m
@@ -1,0 +1,47 @@
+#import "OCKPatient+CMHealth.h"
+#import <CloudMine/CloudMine.h>
+#import "CMHCarePlanStore.h"
+
+@implementation OCKPatient (CMHealth)
+
+- (void)cmh_fetchProfileImageWithCompletion:(_Nullable CMHFetchProfileImageCompletion)block
+{
+    if (![self.store isKindOfClass:[CMHCarePlanStore class]] ||
+        nil == self.userInfo ||
+        nil == self.userInfo[@"photoId"])
+    {
+        if (nil != block) {
+            block(YES, nil, nil);
+        }
+        
+        return;
+    }
+    
+    NSString *photoId = (NSString *)self.userInfo[@"photoId"];
+    CMStoreOptions *shareOption = [CMStoreOptions new];
+    shareOption.shared = YES;
+    
+    [[CMStore defaultStore] userFileWithName:photoId additionalOptions:shareOption callback:^(CMFileFetchResponse *response) {
+        if (nil != response.error) {
+            if (nil != block) {
+                block(NO, nil, response.error);
+            }
+            return;
+        }
+        
+        if (nil == response.file.fileData) {
+            if (nil != block) {
+                block(YES, nil, nil);
+            }
+            return;
+        }
+        
+        UIImage *profileImage = [UIImage imageWithData:response.file.fileData];
+        
+        if (nil != block) {
+            block(YES, profileImage, nil);
+        }
+    }];
+}
+
+@end

--- a/Pod/Classes/OCKPatient+CMHealth.m
+++ b/Pod/Classes/OCKPatient+CMHealth.m
@@ -2,13 +2,19 @@
 #import <CloudMine/CloudMine.h>
 #import "CMHCarePlanStore.h"
 
+NSString * const _Nonnull CMHPatientUserInfoUserDataKey = @"com.cloudmineinc.com.CMHealth.PhotoId";
+NSString * const _Nonnull CMHPatientUserInfoPhotoIdKey = @"com.cloudmineinc.com.CMHealth.PatientData";
+
 @implementation OCKPatient (CMHealth)
+
+// TODO: Accessorthe patient data
+// TODO SOMEDAY: Update patient data from provider side
 
 - (void)cmh_fetchProfileImageWithCompletion:(_Nullable CMHFetchProfileImageCompletion)block
 {
     if (![self.store isKindOfClass:[CMHCarePlanStore class]] ||
         nil == self.userInfo ||
-        nil == self.userInfo[@"photoId"])
+        nil == self.userInfo[CMHPatientUserInfoPhotoIdKey])
     {
         if (nil != block) {
             block(YES, nil, nil);
@@ -17,7 +23,7 @@
         return;
     }
     
-    NSString *photoId = (NSString *)self.userInfo[@"photoId"];
+    NSString *photoId = (NSString *)self.userInfo[CMHPatientUserInfoPhotoIdKey];
     CMStoreOptions *shareOption = [CMStoreOptions new];
     shareOption.shared = YES;
     


### PR DESCRIPTION
This PR adds category methods to `OCKPatient` that allow the access to that patients profile data and profile image if the patient is one which was fetched using an instance of `CMHCarePlanStore`. This allows users in a care provider context, such as doctors using an app to manage their cases, to access patient profile data that was set using the patients `CMHUser` instance.